### PR TITLE
レスポンスに配列が来ても対応できるように修正

### DIFF
--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -68,7 +68,17 @@ module CopyTunerClient
     def html_request?(headers, response)
       headers['Content-Type'] &&
       headers['Content-Type'].include?('text/html') &&
-      response.body.include?("<html")
+      response_body(response).include?("<html")
+    end
+
+    def response_body(response)
+      body = ''
+      if response.is_a?(Array)
+        response.each { |s| body << s }
+      else
+        body = response
+      end
+      body
     end
   end
 end


### PR DESCRIPTION
Rails4系にてxray-rails利用時にresponseに配列が入っている場合のときにエラーが出ていた。