### PR TITLE
I18n::Backend::Fallbacks が効かない不具合の修正

### DIFF
--- a/lib/copy_tuner_client/i18n_backend.rb
+++ b/lib/copy_tuner_client/i18n_backend.rb
@@ -24,7 +24,7 @@ module CopyTunerClient
     #
     # @return [Object] the translated key (usually a String)
     def translate(locale, key, options = {})
-      content = super(locale, key, options.merge(:fallback => true))
+      content = super(locale, key, options)
       if CopyTunerClient.configuration.inline_translation
         content = (content.is_a?(Array) ? content : key.to_s)
       end

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -146,12 +146,13 @@ describe CopyTunerClient::I18nBackend do
       end
     end
 
-    it "queues missing keys with default" do
+    it "queues missing keys with blank string" do
       default = 'default value'
-
       subject.translate('en', 'test.key', :default => default).should == default
 
-      cache['en.test.key'].should == default
+      # default と Fallbacks を併用した場合、キャッシュにデフォルト値は入らない仕様に変えた
+      # その仕様にしないと、うまく Fallbacks の処理が動かないため
+      cache['en.test.key'].should == ''
     end
   end
 end


### PR DESCRIPTION
Fallbacks 使用時、default オプションが指定されたときにサーバーに空文字がアップロードされなくなるという使用変更もある。