### PR TITLE
Hook methods after load_config_initializers

### DIFF
--- a/lib/copy_tuner_client/engine.rb
+++ b/lib/copy_tuner_client/engine.rb
@@ -6,7 +6,9 @@ module CopyTunerClient
   class Engine < ::Rails::Engine
     initializer :initialize_copy_tuner_rails, :before => :load_config_initializers do |app|
       CopyTunerClient::Rails.initialize
+    end
 
+    initializer :initialize_copy_tuner_hook_methods, :after => :load_config_initializers do |app|
       ActiveSupport.on_load(:action_view) do
         ActionView::Helpers::TranslationHelper.class_eval do
           def translate_with_copyray_comment(key, options = {})
@@ -27,6 +29,8 @@ module CopyTunerClient
       if CopyTunerClient.configuration.enable_middleware?
         CopyTunerClient::TranslationLog.install_hook
       end
+
+      require 'copy_tuner_client/simple_form_extention'
     end
 
     initializer "copy_tuner.assets.precompile", group: :all do |app|

--- a/lib/copy_tuner_client/rails.rb
+++ b/lib/copy_tuner_client/rails.rb
@@ -10,7 +10,6 @@ module CopyTunerClient
         config.framework        = "Rails: #{::Rails::VERSION::STRING}"
         config.middleware       = ::Rails.configuration.middleware
       end
-      require 'copy_tuner_client/simple_form_extention'
     end
   end
 end


### PR DESCRIPTION
Rails.env が development や staging 以外のときに、 config.development_environments を設定してもオーバーレイが正しく表示されない不具合の修正。