### PR TITLE
[review] Rails 5.1 に対応するために alias_method_chain を使ってた箇所を Module#prepend に置き換え

### DIFF
--- a/lib/copy_tuner_client/engine.rb
+++ b/lib/copy_tuner_client/engine.rb
@@ -4,6 +4,17 @@ require 'copy_tuner_client/translation_log'
 module CopyTunerClient
   # Connects to integration points for Rails 3 applications
   class Engine < ::Rails::Engine
+    module TranslateWrapper
+      def translate(key, options = {})
+        source = super
+        if !CopyTunerClient.configuration.disable_copyray_comment_injection && (options[:rescue_format] == :html || options[:rescue_format].nil?)
+          CopyTunerClient::Copyray.augment_template(source, scope_key_by_partial(key))
+        else
+          source
+        end
+      end
+    end
+
     initializer :initialize_copy_tuner_rails, :before => :load_config_initializers do |app|
       CopyTunerClient::Rails.initialize
     end
@@ -11,17 +22,9 @@ module CopyTunerClient
     initializer :initialize_copy_tuner_hook_methods, :after => :load_config_initializers do |app|
       ActiveSupport.on_load(:action_view) do
         ActionView::Helpers::TranslationHelper.class_eval do
-          def translate_with_copyray_comment(key, options = {})
-            source = translate_without_copyray_comment(key, options)
-            if !CopyTunerClient.configuration.disable_copyray_comment_injection && (options[:rescue_format] == :html || options[:rescue_format].nil?)
-              CopyTunerClient::Copyray.augment_template(source, scope_key_by_partial(key))
-            else
-              source
-            end
-          end
           if CopyTunerClient.configuration.enable_middleware?
-            alias_method_chain :translate, :copyray_comment
             alias :t :translate
+            prepend CopyTunerClient::Engine::TranslateWrapper
           end
         end
       end

--- a/lib/copy_tuner_client/simple_form_extention.rb
+++ b/lib/copy_tuner_client/simple_form_extention.rb
@@ -7,22 +7,24 @@ end
 
 if defined?(SimpleForm)
   module SimpleForm::Components::Labels
-    protected
-    def label_translation_with_copyray_comment
-      source = label_translation_without_copyray_comment
+    module LabelTranslationWrapper
+      def label_translation
+        source = super
 
-      if !CopyTunerClient.configuration.disable_copyray_comment_injection && object.class.respond_to?(:lookup_ancestors)
-        attributes_scope = "#{object.class.i18n_scope}.attributes"
-        defaults = object.class.lookup_ancestors.map do |klass|
-          "#{attributes_scope}.#{klass.model_name.i18n_key}.#{reflection_or_attribute_name}"
+        if !CopyTunerClient.configuration.disable_copyray_comment_injection && object.class.respond_to?(:lookup_ancestors)
+          attributes_scope = "#{object.class.i18n_scope}.attributes"
+          defaults = object.class.lookup_ancestors.map do |klass|
+            "#{attributes_scope}.#{klass.model_name.i18n_key}.#{reflection_or_attribute_name}"
+          end
+          CopyTunerClient::Copyray.augment_template(source, defaults.shift).html_safe
+        else
+          source
         end
-        CopyTunerClient::Copyray.augment_template(source, defaults.shift).html_safe
-      else
-        source
       end
     end
+
     if CopyTunerClient.configuration.enable_middleware?
-      alias_method_chain :label_translation, :copyray_comment
+      prepend SimpleForm::Components::Labels::LabelTranslationWrapper
     end
   end
 end

--- a/lib/copy_tuner_client/translation_log.rb
+++ b/lib/copy_tuner_client/translation_log.rb
@@ -1,5 +1,22 @@
 module CopyTunerClient
   class TranslationLog
+    module TranslateWrapper
+      def translate(*args)
+        key = args[0]
+        options  = args.last.is_a?(Hash) ? args.last : {}
+        scope = options[:scope]
+        scope = scope.dup if scope.is_a?(Array) || scope.is_a?(String)
+        result = super(*args)
+
+        if key.is_a?(Array)
+          key.zip(result).each { |k, v| CopyTunerClient::TranslationLog.add(I18n.normalize_keys(nil, k, scope).join('.'), v) unless v.is_a?(Array) }
+        else
+          CopyTunerClient::TranslationLog.add(I18n.normalize_keys(nil, key, scope).join('.'), result) unless result.is_a?(Array)
+        end
+        result
+      end
+    end
+
     def self.translations
       Thread.current[:translations]
     end
@@ -19,23 +36,9 @@ module CopyTunerClient
     def self.install_hook
       I18n.class_eval do
         class << self
-          def translate_with_copy_tuner_hook(*args)
-            key = args[0]
-            options  = args.last.is_a?(Hash) ? args.last : {}
-            scope = options[:scope]
-            scope = scope.dup if scope.is_a?(Array) || scope.is_a?(String)
-            result = translate_without_copy_tuner_hook(*args)
-
-            if key.is_a?(Array)
-              key.zip(result).each { |k, v| CopyTunerClient::TranslationLog.add(I18n.normalize_keys(nil, k, scope).join('.'), v) unless v.is_a?(Array) }
-            else
-              CopyTunerClient::TranslationLog.add(I18n.normalize_keys(nil, key, scope).join('.'), result) unless result.is_a?(Array)
-            end
-            result
-          end
           if CopyTunerClient.configuration.enable_middleware?
-            alias_method_chain :translate, :copy_tuner_hook
             alias :t :translate
+            prepend CopyTunerClient::TranslationLog::TranslateWrapper
           end
         end
       end


### PR DESCRIPTION
@shunichi 

Rails 5.1 で動くようにするためにいじって見たー
手元の console & puma では上手く動いてる & rspec も全部通ってるけど、念のためまずい箇所が無いかとか見て欲しい