### PR TITLE
Fix copyray injection

### DIFF
--- a/lib/copy_tuner_client/configuration.rb
+++ b/lib/copy_tuner_client/configuration.rb
@@ -128,6 +128,14 @@ module CopyTunerClient
 
     alias_method :secure?, :secure
 
+    def copyray_js_injection_regexp_for_debug=(value)
+      logger.warn 'DEPRECATION WARNING: copyray_js_injection_regexp_for_debug is deprecated'
+    end
+
+    def copyray_js_injection_regexp_for_precompiled=(value)
+      logger.warn 'DEPRECATION WARNING: copyray_js_injection_regexp_for_precompiled is deprecated'
+    end
+
     # Instantiated from {CopyTunerClient.configure}. Sets defaults.
     def initialize
       self.client_name = 'CopyTuner Client'
@@ -145,20 +153,6 @@ module CopyTunerClient
       self.test_environments = %w(test cucumber)
       self.s3_host = 'copy-tuner-data-prod.s3.amazonaws.com'
       self.disable_copyray_comment_injection = false
-
-      # Matches:
-      #   <script src="/assets/jquery.js"></script>
-      #   <script src="/assets/jquery-min.js"></script>
-      #   <script src="/assets/jquery.min.1.9.1.js"></script>
-      #   <script src="/assets/jquery.self-xxxxxx.js"></script>
-      #   <script src="/assets/jquery2.self-a4777c1acac0a74340755725342901a54ed000955bf6f5320491b8b2514c86ec.js?body=1" data-turbolinks-track="true"></script>
-      #   <script src="/assets/jquery-09abf132254111788afa8aca28fc7872.js?body=1"></script>
-      self.copyray_js_injection_regexp_for_debug = /<script[^>]+\/jquery[23]?([-.]{1}[\d\.]+)?([-.]{1}min(\.[\d\.]+)?)?(\.self)?(\-[\da-f]+)?\.js[^>]+><\/script>/
-
-      # Matches:
-      #   <script src="/application-xxxxxxx.js"></script>
-      #   <script src="/application.js"></script>
-      self.copyray_js_injection_regexp_for_precompiled = /<script[^>]+\/application.*\.js[^>]+><\/script>/
 
       @applied = false
     end

--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -45,7 +45,7 @@ module CopyTunerClient
     end
 
     def inject_copy_tuner_bar(html)
-      html.sub(/<body[^>]*>/) { "#{$~}\n#{render_copy_tuner_bar}" }
+      html.sub(/<body[^>]*>/) { "#{Regexp.last_match}\n#{render_copy_tuner_bar}" }
     end
 
     def render_copy_tuner_bar
@@ -60,12 +60,12 @@ module CopyTunerClient
     end
 
     def append_css(html)
-      html.sub(/<body[^>]*>/) { "#{$~}\n#{css_tag}" }
+      html.sub(/<body[^>]*>/) { "#{Regexp.last_match}\n#{css_tag}" }
     end
 
     def append_js(html)
       html.sub(%r{</body>}) do
-       "#{helpers.javascript_include_tag(:copyray)}\n#{$~}"
+       "#{helpers.javascript_include_tag(:copyray)}\n#{Regexp.last_match}"
       end
     end
 

--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -64,13 +64,8 @@ module CopyTunerClient
     end
 
     def append_js(html)
-      regexp = if ::Rails.application.config.assets.debug
-                 CopyTunerClient.configuration.copyray_js_injection_regexp_for_debug
-               else
-                 CopyTunerClient.configuration.copyray_js_injection_regexp_for_precompiled
-               end
-      html.sub(regexp) do
-        "#{$~}\n" + helpers.javascript_include_tag(:copyray)
+      html.sub(%r{</body>}) do
+       "#{helpers.javascript_include_tag(:copyray)}\n#{$~}"
       end
     end
 

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -190,18 +190,6 @@ describe CopyTunerClient::Configuration do
     expect(prefixed_logger).to be_a(CopyTunerClient::PrefixedLogger)
     expect(prefixed_logger.original_logger).to eq(logger)
   end
-
-  describe 'copyray_js_injection_regexp_for_debug' do
-    let(:config) { CopyTunerClient::Configuration.new }
-    subject { config.copyray_js_injection_regexp_for_debug }
-
-    it { is_expected.to match '<script src="/assets/jquery.js"></script>' }
-    it { is_expected.to match '<script src="/assets/jquery-min.js"></script>' }
-    it { is_expected.to match '<script src="/assets/jquery.min.1.9.1.js"></script>' }
-    it { is_expected.to match '<script src="/assets/jquery/jquery.self-a4777c1acac0a74340755725342901a54ed000955bf6f5320491b8b2514c86ec.js?body=1" data-turbolinks-track="true"></script>' }
-    it { is_expected.to match '<script src="/assets/jquery2.self-a4777c1acac0a74340755725342901a54ed000955bf6f5320491b8b2514c86ec.js?body=1" data-turbolinks-track="true"></script>' }
-    it { is_expected.to match '<script src="/assets/jquery-09abf132254111788afa8aca28fc7872.js?body=1"></script>' }
-  end
 end
 
 shared_context 'stubbed configuration' do


### PR DESCRIPTION
今までcopyrayのjsをjqueryのscriptタグの下に挿入するようにしてたけど、jquery依存を切ったので挿入されなくなることがあった。

bodyの閉じタグの直前にいれるようにしてみた。
元々それでよかったのでは？と思うけど、何か問題があるのだろうか？
