### PR TITLE
[review] async synchronization

### DIFF
--- a/lib/copy_tuner_client.rb
+++ b/lib/copy_tuner_client.rb
@@ -12,10 +12,6 @@ module CopyTunerClient
     # Must act like a hash and return sensible values for all CopyTuner
     # configuration options. Usually set when {.configure} is called.
     attr_accessor :configuration
-
-    # @return [Poller] instance used to poll for changes.
-    # This is set when {.configure} is called.
-    attr_accessor :poller
   end
 
   # Issues a new deploy, marking all draft blurbs as published.
@@ -30,11 +26,6 @@ module CopyTunerClient
     cache.export
   end
 
-  # Starts the polling process.
-  def self.start_poller
-    poller.start
-  end
-
   # Flush queued changed synchronously
   def self.flush
     cache.flush
@@ -46,6 +37,10 @@ module CopyTunerClient
 
   def self.client
     CopyTunerClient.configuration.client
+  end
+
+  def self.poller
+    CopyTunerClient.configuration.poller
   end
 
   # Call this method to modify defaults in your initializers.

--- a/lib/copy_tuner_client/cache.rb
+++ b/lib/copy_tuner_client/cache.rb
@@ -13,15 +13,16 @@ module CopyTunerClient
     # @param options [Hash]
     # @option options [Logger] :logger where errors should be logged
     def initialize(client, options)
-      @blurbs = {}
       @client = client
-      @downloaded = false
       @logger = options[:logger]
       @mutex = Mutex.new
-      @queued = {}
-      @started = false
       @exclude_key_regexp = options[:exclude_key_regexp]
       @locales = Array(options[:locales]).map(&:to_s)
+      # mutable states
+      @blurbs = {}
+      @queued = {}
+      @started = false
+      @downloaded = false
     end
 
     # Returns content for the given blurb.

--- a/lib/copy_tuner_client/client.rb
+++ b/lib/copy_tuner_client/client.rb
@@ -47,13 +47,15 @@ module CopyTunerClient
       connect(s3_host) do |http|
         request = Net::HTTP::Get.new(uri(download_resource))
         request['If-None-Match'] = @etag
+        log 'Start downloading translations'
+        t = Time.now
         response = http.request(request)
-
+        t_ms = ((Time.now - t) * 1000).to_i
         if check response
-          log 'Downloaded translations'
+          log "Downloaded translations (#{t_ms}ms)"
           yield JSON.parse(response.body)
         else
-          log 'No new translations'
+          log "No new translations (#{t_ms}ms)"
         end
 
         @etag = response['ETag']

--- a/lib/copy_tuner_client/queue_with_timeout.rb
+++ b/lib/copy_tuner_client/queue_with_timeout.rb
@@ -1,0 +1,50 @@
+module CopyTunerClient
+  # https://spin.atomicobject.com/2014/07/07/ruby-queue-pop-timeout/
+  class QueueWithTimeout
+    def initialize
+      @mutex = Mutex.new
+      @queue = []
+      @received = ConditionVariable.new
+    end
+
+    def <<(x)
+      @mutex.synchronize do
+        @queue << x
+        @received.signal
+      end
+    end
+
+    def uniq_push(x)
+      @mutex.synchronize do
+        unless @queue.member?(x)
+          @queue << x
+          @received.signal
+        end
+      end
+    end
+
+    def pop(non_block = false)
+      pop_with_timeout(non_block ? 0 : nil)
+    end
+
+    def pop_with_timeout(timeout = nil)
+      @mutex.synchronize do
+        if timeout.nil?
+          # wait indefinitely until there is an element in the queue
+          while @queue.empty?
+            @received.wait(@mutex)
+          end
+        elsif @queue.empty? && timeout != 0
+          # wait for element or timeout
+          timeout_time = timeout + Time.now.to_f
+          while @queue.empty? && (remaining_time = timeout_time - Time.now.to_f) > 0
+            @received.wait(@mutex, remaining_time)
+          end
+        end
+        #if we're still empty after the timeout, raise exception
+        raise ThreadError, "queue empty" if @queue.empty?
+        @queue.shift
+      end
+    end
+  end
+end

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -95,14 +95,4 @@ describe CopyTunerClient::Poller do
 
     expect(logger).to have_received(:flush).at_least_once
   end
-
-  it "starts from the top-level constant" do
-    poller = build_poller
-    CopyTunerClient.poller = poller
-    poller.stubs(:start)
-
-    CopyTunerClient.start_poller
-
-    expect(poller).to have_received(:start)
-  end
 end


### PR DESCRIPTION
- request_sync middleware でサーバーにアクセスしてブロックしていた部分をpollerスレッドに逃がして非同期化した
- ステージングサーバーではデフォルト設定で毎回サーバーと同期していたので影響が大きい
- リクエスト毎に1.5秒〜3秒くらいかかっていたのがほぼ0になる
- リクエスト処理前にダウンロードを待っていたのがなくなったので、翻訳データの反映が若干遅くなるが、2秒ほど待つくらいなら問題ないと判断

