### PR TITLE
[review] script タグに type module を追加

### DIFF
--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -49,7 +49,7 @@ module CopyTunerClient
           data: #{json},
         }
       SCRIPT
-      append_to_html_body(html, helpers.javascript_include_tag(:main))
+      append_to_html_body(html, helpers.javascript_include_tag(:main, type: 'module'))
     end
 
     def css_tag

--- a/lib/copy_tuner_client/version.rb
+++ b/lib/copy_tuner_client/version.rb
@@ -1,6 +1,6 @@
 module CopyTunerClient
   # Client version
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.13.1'.freeze
 
   # API version being used to communicate with the server
   API_VERSION = '2.0'.freeze


### PR DESCRIPTION
turbolinks の環境でページ遷移のたびに下記のJSエラーが発生していたため修正。

```
Uncaught ReferenceError: HIDDEN_CLASS is not defined
```