### PR TITLE
[review] Fixed checking process for event.key

### DIFF
--- a/app/assets/javascripts/copytuner.js
+++ b/app/assets/javascripts/copytuner.js
@@ -373,7 +373,7 @@ const start = () => {
       copyray2.hide();
       return;
     }
-    if ((isMac && event.metaKey || !isMac && event.ctrlKey) && event.shiftKey && event.key === "k") {
+    if ((isMac && event.metaKey || !isMac && event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === "k") {
       copyray2.toggle();
     }
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ const start = () => {
       return
     }
 
-    if (((isMac && event.metaKey) || (!isMac && event.ctrlKey)) && event.shiftKey && event.key === 'k') {
+    if (((isMac && event.metaKey) || (!isMac && event.ctrlKey)) && event.shiftKey && event.key.toLowerCase() === 'k') {
       copyray.toggle()
     }
   })


### PR DESCRIPTION
Mac以外の場合、Shiftキーが押されていることによって`event.key`の値が大文字のKになる