### PR TITLE
[review] Allow 422 status in HTML header check

### DIFF
--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -67,7 +67,7 @@ module CopyTunerClient
     end
 
     def html_headers?(status, headers)
-      status == 200 &&
+      [200, 422].include?(status) &&
       headers['Content-Type'] &&
       headers['Content-Type'].include?('text/html') &&
       !file?(headers)

--- a/lib/copy_tuner_client/version.rb
+++ b/lib/copy_tuner_client/version.rb
@@ -1,6 +1,6 @@
 module CopyTunerClient
   # Client version
-  VERSION = '1.1.3'.freeze
+  VERSION = '1.1.4'.freeze
 
   # API version being used to communicate with the server
   API_VERSION = '2.0'.freeze


### PR DESCRIPTION
`render :new, status: :unprocessable_entity`みたいなケースで効いていなかった。