### PR TITLE
docs: copy-tuner スキルに I18n メソッドの使い分けセクションを追加

### DIFF
--- a/skills/copy-tuner/SKILL.md
+++ b/skills/copy-tuner/SKILL.md
@@ -25,10 +25,23 @@ license: MIT
 
 1. `search_key` で機能名・画面名を英語キーワードで検索し、命名パターンを把握する（例: `search_key("move_out")` で退去関連のキー名の構造を確認する）
 2. パターンに合わせたキー名を決める
-3. ja は必須。他に必要なロケールは `get_locales` で確認し、日本語以外は文脈に応じて翻訳して登録する
-4. コード内で `t("登録したキー名")` として使用する
+3. ja は必須。他に必要なロケールは `get_locales` で確認し、存在するロケール分を翻訳して登録する
+4. コード内で翻訳キーを使用する（`t` と `tt` の使い分けは「I18nメソッドの使い分け」セクション参照）
 
 ## 不要なキーの処理
 
 コード削除等で不要になったキーは削除せず `config/initializers/copy_tuner.rb` の `ignored_keys` に追加する。
 一定期間どこからも参照されていないことを確認してから手動削除する。
+
+## I18nメソッドの使い分け
+
+- **`t`メソッド**: 通常のテキスト出力に使用
+- **`tt`メソッド**: **HTML要素の属性値**に使用（必須）。copy_tuner_client gem の `HelperExtension` が提供するエイリアス。
+
+**理由**: CopyTunerの影響で `t` はHTMLコメント (`<!-- ... -->`) を埋め込みます。属性値に含まれると意図しない表示や動作不良の原因となります。
+
+```erb
+<div title="<%= tt('views.tooltips.help_text') %>">...</div>
+<input placeholder="<%= tt('views.forms.enter_name') %>">
+<h1><%= t('views.simulation.show.title') %></h1>
+```


### PR DESCRIPTION
`t` と `tt` の使い分けルール（HTML属性値には `tt` が必須）と その理由（CopyTuner が `t` に HTML コメントを埋め込む挙動）を明記する。 新規キー登録フローのロケール登録手順も具体化した。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>