### PR TITLE
docs: copy-tuner スキルの説明を改善し local_first キー管理の判別フローを追加

### DIFF
--- a/skills/copy-tuner/SKILL.md
+++ b/skills/copy-tuner/SKILL.md
@@ -1,47 +1,58 @@
 ---
 name: copy-tuner
-description: "copy_tuner を使った i18n キーの操作スキル。「翻訳キーを調べて」「i18nキーを追加して」「このテキストのキーは？」「i18nキーを探して」「翻訳を確認して」「copy_tunerで調べて」のような依頼に必ず使用する。新しい翻訳キーが必要な実装時、既存キーを参照する時、不要になったキーを処理する時にも積極的に使用する。重要: config/locales ディレクトリや .yml 翻訳ファイルを読もうとしたとき・参照しようとしたときは、必ずこのスキルを使うこと。このプロジェクトの i18n は config/locales ではなく copy_tuner で管理されているため、config/locales を読んでも翻訳は見つからない。"
+description: "このプロジェクトの i18n キー（翻訳）の参照・追加・更新・削除を行うスキル。i18n / 翻訳 / ロケール / `t` / `tt` / 翻訳キーに関わる操作のとき、および `config/locales` ディレクトリや `.yml` 翻訳ファイルを読む・参照する・編集するときは必ず使用すること。翻訳は原則 copy_tuner サーバで管理されており（一部キーのみ config/locales 管理）、素朴に config/locales を読むだけでは大半の翻訳が見つからず誤った判断をするため、必ずこのスキルの手順に従う。"
 license: MIT
 ---
 
 # copy_tuner スキル
 
-このプロジェクトの i18n は `config/locales` ではなく **copy_tuner** で管理している。
-キーの参照・登録・更新は copy_tuner MCP ツールで行う。
+このプロジェクトの i18n は原則 **copy_tuner** サーバで管理し、MCP ツールで操作する。
+例外として `local_first_key_regexp` にマッチするキーだけは `config/locales/*.yml` で管理される。
+**どちらの管理かを最初に判別する。**
 
-## 操作の判断
+## キーの管理場所の判別
 
-| やりたいこと | 使うツール |
+1. `config/initializers/copy_tuner.rb` の `local_first_key_regexp` を確認する（未設定なら全キー copy_tuner）。
+2. 対象キーから **locale を除いた形**（`ja.views.foo` → `views.foo`）がその正規表現にマッチするか見る。
+
+| 判別 | 管理場所 | 操作 |
+|---|---|---|
+| マッチする | config/locales（copy_tuner と完全分離） | `config/locales/*.yml` を Read / Edit |
+| マッチしない・未設定 | copy_tuner | MCP ツール（下記） |
+
+**config/locales 管理キーの落とし穴:**
+- copy_tuner には存在しないので、MCP ツールで探しても見つからない。`config/locales` を見ること。
+- copy_tuner に登録しても lookup でバイパスされ無効。必ず `.yml` 側に書く。
+- ja が無ければ未訳（`nil`）。copy_tuner にフォールバックしない（移行漏れを顕在化させる設計）。
+- prefix 単位の一括移行は別作業。必要なら `skills/copy-tuner-to-locales-migrate-prefix/` を使う。
+
+## copy_tuner MCP ツール
+
+| やりたいこと | ツール |
 |---|---|
-| キー名（または一部）から翻訳を調べる | `search_key` |
+| キー名（一部）から翻訳を調べる | `search_key`（引数は英語キーワード） |
 | 画面テキストからキーを逆引き | `search_translations` |
 | 新しいキーを登録する | `create_i18n_key` |
-| 既存キーの翻訳を更新する | `get_edit_url` でブラウザ編集 |
+| 既存キーの翻訳を更新する | `get_edit_url`（ブラウザ編集） |
 | 使用中ロケールを確認 | `get_locales` |
 
-> **使い分け**: キー名の一部（ドット区切りの名前空間など）が分かっているなら `search_key`（引数は英語のキーワード）。テキスト（日本語・英語の表示文言）しか分からないなら `search_translations`。命名パターンを調べたいときは両方試す。
+## 新規キー登録
 
-## 新規キー登録のフロー
-
-1. `search_key` で機能名・画面名を英語キーワードで検索し、命名パターンを把握する（例: `search_key("move_out")` で退去関連のキー名の構造を確認する）
-2. パターンに合わせたキー名を決める
-3. ja は必須。他に必要なロケールは `get_locales` で確認し、存在するロケール分を翻訳して登録する
-4. コード内で翻訳キーを使用する（`t` と `tt` の使い分けは「I18nメソッドの使い分け」セクション参照）
+1. `search_key` で関連キーを検索し、既存の命名パターンに合わせる（例: `search_key("move_out")`）。
+2. ja は必須。他は `get_locales` で確認し、存在するロケール分を登録する。
 
 ## 不要なキーの処理
 
-コード削除等で不要になったキーは削除せず `config/initializers/copy_tuner.rb` の `ignored_keys` に追加する。
+削除せず `config/initializers/copy_tuner.rb` の `ignored_keys` に追加する。
 一定期間どこからも参照されていないことを確認してから手動削除する。
 
-## I18nメソッドの使い分け
+## `t` と `tt` の使い分け
 
-- **`t`メソッド**: 通常のテキスト出力に使用
-- **`tt`メソッド**: **HTML要素の属性値**に使用（必須）。copy_tuner_client gem の `HelperExtension` が提供するエイリアス。
-
-**理由**: CopyTunerの影響で `t` はHTMLコメント (`<!-- ... -->`) を埋め込みます。属性値に含まれると意図しない表示や動作不良の原因となります。
+**HTML 要素の属性値には `tt` を使う**（それ以外の通常出力は `t`）。`tt` は copy_tuner_client gem の
+`HelperExtension` が提供するエイリアス。`t` は CopyTuner の都合で HTML コメント (`<!-- ... -->`) を
+埋め込むため、属性値に入ると表示崩れや動作不良の原因になる。
 
 ```erb
 <div title="<%= tt('views.tooltips.help_text') %>">...</div>
-<input placeholder="<%= tt('views.forms.enter_name') %>">
 <h1><%= t('views.simulation.show.title') %></h1>
 ```


### PR DESCRIPTION
## Summary

- `local_first_key_regexp` にマッチするキーの管理場所（config/locales vs copy_tuner）を判別するフローを追加
- キー管理場所ごとの落とし穴（copy_tuner に登録しても無効、フォールバックなし等）を明記
- スキルの description をより明確・簡潔に整理し、トリガー条件を改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)