### PR TITLE
[review] fix: local_first_key チェックを ignored_keys より先に評価するよう順序を修正

### DIFF
--- a/lib/copy_tuner_client/i18n_backend.rb
+++ b/lib/copy_tuner_client/i18n_backend.rb
@@ -69,15 +69,16 @@ module CopyTunerClient
       key_with_locale = parts.join('.')
       key_without_locale = parts[1..].join('.')
 
-      if CopyTunerClient::configuration.ignored_keys.include?(key_without_locale)
-        CopyTunerClient::configuration.ignored_key_handler.call(IgnoredKey.new("Ignored key: #{key_without_locale}"))
-      end
-
       # NOTE: local_first_key_regexp にマッチするキーは copy_tuner キャッシュをスキップし、
       # ローカル config/locales（I18n::Backend::Simple）を優先する。段階的にローカルへ移行するための仕組み。
       # ローカルに無い場合は nil（未訳）のまま返し、copy_tuner へのフォールバックも空キー登録も行わない（完全分離）。
+      # ignored_keys より先に評価することで、両方にマッチするキーでも確実にローカルへ委譲する。
       if local_first_key?(key_without_locale)
         return super
+      end
+
+      if CopyTunerClient::configuration.ignored_keys.include?(key_without_locale)
+        CopyTunerClient::configuration.ignored_key_handler.call(IgnoredKey.new("Ignored key: #{key_without_locale}"))
       end
 
       # NOTE: ハッシュ化した場合に削除されるキーに対応するため、最初に完全一致をチェック（旧クライアントの動作を維持）


### PR DESCRIPTION
<!-- pr-summary-start -->
## 背景・課題

`local_first_key_regexp` にマッチするキーは、CopyTuner キャッシュをスキップしてローカルの `config/locales`（I18n::Backend::Simple）を優先するための仕組み。

しかし `ignored_keys` チェックが先に実行されていたため、**両方の条件にマッチするキー**（`local_first_key` かつ `ignored_keys` に含まれる）では、`local_first` の処理より先に `ignored_key_handler` が呼ばれてしまう不整合があった。

## 変更内容

`lib/copy_tuner_client/i18n_backend.rb` の `lookup` メソッド内で、評価順序を入れ替えた：

- **変更前**: `ignored_keys` チェック → `local_first_key?` チェック
- **変更後**: `local_first_key?` チェック → `ignored_keys` チェック

これにより、`local_first_key?` が `true` の場合は即座に `super`（ローカルバックエンドへ委譲）に返り、`ignored_key_handler` は呼ばれなくなる。あわせて `local_first_key` のコメントに評価順の意図を明記した。

## レビューのポイント

- `local_first_key` かつ `ignored_keys` の両方にマッチするキーが実運用で存在するケースを想定した変更。そのようなキーが実際にある場合、`ignored_key_handler`（通知・ログ等）が呼ばれなくなる点が仕様として意図通りか確認を。
<!-- pr-summary-end -->