### PR TITLE
[review] fix: 数値セグメントを含む i18n キーで tree_cache 探索がクラッシュする問題を修正

### DIFF
--- a/lib/copy_tuner_client/i18n_backend.rb
+++ b/lib/copy_tuner_client/i18n_backend.rb
@@ -117,7 +117,9 @@ module CopyTunerClient
     def lookup_in_tree_cache(keys)
       return nil if @tree_cache.nil?
 
-      symbol_keys = keys.map(&:to_sym)
+      # NOTE: keys は I18n.normalize_keys 済みの配列で、数字だけのセグメントは Integer になっている
+      # （例: "...body_temperature.36.5" は [..., 36, 5] に分割される）。Integer#to_sym は無いため to_s を経由する。
+      symbol_keys = keys.map { |k| k.to_s.to_sym }
       begin
         result = @tree_cache.dig(*symbol_keys)
         result.is_a?(Hash) ? result : nil

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -425,6 +425,23 @@ describe 'CopyTunerClient::I18nBackend' do
         result = subject.translate('ja', 'hoge.hello', default: nil)
         expect(result).to be_nil
       end
+
+      it '数値セグメントを含むキー（数値enum）でクラッシュしないこと' do
+        # NOTE: enumerize の Float range など、normalize_keys が末尾を Integer に分割するキー。
+        # exact_match（完全一致）を回避するため別キーを格納し、tree_cache 探索経路を必ず通す。
+        cache['ja.dummy'] = 'dummy'
+
+        expect {
+          subject.translate('ja', 'enumerize.infection_control.body_temperature.36.5', default: nil)
+        }.not_to raise_error
+      end
+
+      it '数値セグメントキーが存在しても通常キーのlookupが壊れないこと' do
+        cache['ja.views.hoge'] = 'normal'
+
+        expect { subject.translate('ja', 'enumerize.body_temperature.36.5', default: nil) }.not_to raise_error
+        expect(subject.translate('ja', 'views.hoge')).to eq('normal')
+      end
     end
   end
 


### PR DESCRIPTION
<!-- pr-summary-start -->
## 背景・課題

CopyTuner クライアントは I18n backend を差し替え、`lookup_in_tree_cache` でキャッシュ済みの blurb ツリーをキー配列で辿る。このキー配列は `I18n.normalize_keys` を通った後のもので、ドット区切りのキーがセグメントに分割される際、数字だけのセグメントは Symbol ではなく Integer に変換される。

enumerize の Float range（例: `body_temperature.36.5`）のように末尾が数値になるキーを翻訳しようとすると、配列が `[..., 36, 5]` のように Integer を含む。従来コードは各セグメントに `to_sym` を呼んでいたが `Integer#to_sym` は存在しないため、`NoMethodError` でクラッシュしていた。

## 変更内容

- `lib/copy_tuner_client/i18n_backend.rb` の `lookup_in_tree_cache` で、各セグメントを `k.to_sym` から `k.to_s.to_sym` に変更。Integer セグメントをいったん文字列化してから Symbol 化することで、`dig` に渡すキー配列を安全に組み立てる。Integer を特別扱いして分岐するのではなく、全セグメントを一律 `to_s` 経由にすることで意図（Symbol 配列に正規化する）を素直に表現している。
- なぜ Integer が混ざるのかが分かりにくいため、`I18n.normalize_keys` の挙動を説明する NOTE コメントを併記。
- `spec/copy_tuner_client/i18n_backend_spec.rb` に 2 ケース追加。(1) 数値セグメントを含むキーでクラッシュしないこと、(2) 数値セグメントキーの存在が通常キーの lookup を壊さないこと。前者では `exact_match` で早期 return されると tree_cache 探索経路を通らないため、あえて別キーを格納して探索経路を必ず通すよう工夫している。
