### PR TITLE
[review] feat: Rails 標準の number.*.format キーを常にローカル優先にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ CopyTuner で一元管理している翻訳を、`views.*` のような単位で
 - ローカル YAML にも存在しない場合は未訳（`nil` / MissingTranslation）となります。CopyTuner へのフォールバックや新規キーのアップロードは行いません。これにより移行漏れを未訳として検知できます。
 - マッチしたキーには、ビューヘルパー（`t` / `translate`）および SimpleForm のラベルで CopyRay オーバーレイマーカー（`<!--COPYRAY key-->`）を注入しません。これらのキーは CopyTuner 上で編集できないため、編集可能だと誤認させないためです。
 
+### Rails 標準の数値フォーマットキーは常にローカル優先（組み込み）
+
+`local_first_key_regexp` の設定有無にかかわらず、以下の Rails 標準キーは**常にローカル YAML 優先**になります（CopyTuner をバイパス）。
+
+- `number.format` / `number.currency.format` / `number.percentage.format` / `number.human.format`（およびその配下）
+
+これらは `precision`（整数）や `significant` / `strip_insignificant_zeros`（真偽値）といった非文字列値を含みます。CopyTuner は文字列値しか保持できないため、経由するとこれらが欠落し、`number_to_currency` などが意図しない表示（小数桁数や記号の崩れ）になります。これを防ぐため gem 側で固定的にローカル優先にしています。
+
+アプリ独自の `number.*` キー（例 `number.gift_amount`）は対象外で、従来どおり CopyTuner で管理できます。
+
 `exclude_key_regexp` との違い:
 
 | オプション | 対象 | 作用するタイミング |

--- a/lib/copy_tuner_client/cache.rb
+++ b/lib/copy_tuner_client/cache.rb
@@ -56,8 +56,8 @@ module CopyTunerClient
 
       # NOTE: config/locales以下のファイルに除外キーが残っていた場合の対応
       key_without_locale = key.split('.')[1..].join('.')
-      # NOTE: local_first_key_regexp にマッチするキーは copy_tuner と完全分離するためアップロードしない
-      return if @local_first_key_regexp && key_without_locale.match?(@local_first_key_regexp)
+      # NOTE: local_first キー（組み込みの Rails number.*.format + ユーザー設定）は copy_tuner と完全分離するためアップロードしない
+      return if local_first_key?(key_without_locale)
 
       if @ignored_keys.include?(key_without_locale)
         @ignored_key_handler.call(IgnoredKey.new("Ignored key: #{key_without_locale}"))
@@ -164,6 +164,14 @@ module CopyTunerClient
     private
 
     attr_reader :client, :logger
+
+    # NOTE: 組み込みの Rails number.*.format キーは lookup 経路（Configuration#local_first_key?）と
+    # アップロード抑止経路（ここ）で同じ判定を共有する。判定本体は Configuration に集約し付け忘れの穴を防ぐ。
+    def local_first_key?(key_without_locale)
+      return true if Configuration.builtin_local_first_key?(key_without_locale)
+
+      @local_first_key_regexp && key_without_locale.match?(@local_first_key_regexp)
+    end
 
     def with_queued_changes
       changes_to_push = nil

--- a/lib/copy_tuner_client/configuration.rb
+++ b/lib/copy_tuner_client/configuration.rb
@@ -21,6 +21,21 @@ module CopyTunerClient
                  ca_file exclude_key_regexp local_first_key_regexp s3_host locales ignored_keys ignored_key_handler
                  download_cache_dir].freeze
 
+    # NOTE: Rails 標準ロケールで非文字列値（precision: Integer, significant: Boolean,
+    # strip_insignificant_zeros: Boolean）を含むのは number.*.format 配下のみ。store_item が文字列しか
+    # 保持できず lookup_in_tree_cache が tree cache をローカル YAML より優先するため、CopyTuner 経由だと
+    # precision 等が欠落し number_to_currency 等が壊れる。これらの Rails 標準 format キーだけを常にローカル
+    # 優先にする（number 全体ではなく、アプリ独自の number.* キーは対象外）。末尾 (\.|\z) で
+    # number.currency.format（ハッシュ lookup）と number.currency.format.precision（葉キー）の両方に対応する。
+    BUILTIN_LOCAL_FIRST_KEY_REGEXP =
+      /\Anumber\.(format|currency\.format|percentage\.format|human\.format)(\.|\z)/
+
+    # lookup 経路（Configuration#local_first_key?）と upload 抑止経路（Cache#[]=）で同じ組み込み判定を
+    # 共有する。判定を 1 箇所に集約することで number 以外を足す際の同期漏れを防ぐ。
+    def self.builtin_local_first_key?(key_without_locale)
+      key_without_locale.to_s.match?(BUILTIN_LOCAL_FIRST_KEY_REGEXP)
+    end
+
     # @return [String] The API key for your project, found on the project edit form.
     attr_reader :api_key
 
@@ -363,9 +378,13 @@ module CopyTunerClient
     # @param key_without_locale [String, Symbol, nil] locale prefix を除いたキー（例: "views.foo.bar"）
     # @return [Boolean]
     def local_first_key?(key_without_locale)
-      return false if local_first_key_regexp.nil? || key_without_locale.nil?
+      return false if key_without_locale.nil?
 
-      key_without_locale.to_s.match?(local_first_key_regexp)
+      normalized = key_without_locale.to_s
+      return true if self.class.builtin_local_first_key?(normalized)
+      return false if local_first_key_regexp.nil?
+
+      normalized.match?(local_first_key_regexp)
     end
 
     private

--- a/skills/copy-tuner/SKILL.md
+++ b/skills/copy-tuner/SKILL.md
@@ -20,6 +20,11 @@ license: MIT
 | マッチする | config/locales（copy_tuner と完全分離） | `config/locales/*.yml` を Read / Edit |
 | マッチしない・未設定 | copy_tuner | MCP ツール（下記） |
 
+**例外（gem 組み込み・設定不要で常に config/locales 管理）:** Rails 標準の `number.format` /
+`number.currency.format` / `number.percentage.format` / `number.human.format`（およびその配下）。
+`precision` 等の非文字列値を含み copy_tuner では正しく扱えないため、gem が常にバイパスする。
+これらは `config/locales/*.yml` を見る・編集すること（アプリ独自の `number.gift_amount` 等は対象外で通常どおり copy_tuner）。
+
 **config/locales 管理キーの落とし穴:**
 - copy_tuner には存在しないので、MCP ツールで探しても見つからない。`config/locales` を見ること。
 - copy_tuner に登録しても lookup でバイパスされ無効。必ず `.yml` 側に書く。

--- a/spec/copy_tuner_client/cache_spec.rb
+++ b/spec/copy_tuner_client/cache_spec.rb
@@ -55,6 +55,18 @@ describe 'CopyTunerClient::Cache' do
     expect(cache.queued.keys).to match_array(%w[ja.views.foo ja.messages.bar])
   end
 
+  it 'Rails標準の number.*.format キーは設定なしでもアップロードしないこと' do
+    cache = build_cache(local_first_key_regexp: nil)
+    cache['ja.number.currency.format.unit'] = '$'
+    cache['ja.number.gift_amount']          = 'app key'
+    cache['ja.messages.bar']                = 'copy tuner value'
+
+    cache.download
+
+    # number.*.format のみ抑止。アプリ独自 number キーと通常キーは従来どおりアップロード
+    expect(cache.queued.keys).to match_array(%w[ja.number.gift_amount ja.messages.bar])
+  end
+
   it '変更がない場合はアップロードしないこと' do
     cache = build_cache
     cache.flush

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -217,6 +217,40 @@ describe CopyTunerClient::Configuration do
         expect(config.local_first_key?(:'views.foo')).to eq true
       end
     end
+
+    # NOTE: Rails 標準の number.*.format 配下は precision 等の非文字列値を含み CopyTuner 経由だと壊れるため、
+    # ユーザー設定の有無によらず常にローカル優先（組み込み判定）になる
+    context 'with built-in Rails number format keys' do
+      it 'returns true for built-in number format keys even when local_first_key_regexp is nil' do
+        expect(config.local_first_key?('number.format')).to eq true
+        expect(config.local_first_key?('number.currency.format')).to eq true
+        expect(config.local_first_key?('number.currency.format.precision')).to eq true
+        expect(config.local_first_key?('number.percentage.format')).to eq true
+        expect(config.local_first_key?('number.human.format.significant')).to eq true
+      end
+
+      it 'returns false for app-defined number keys (not Rails format subtrees)' do
+        expect(config.local_first_key?('number.gift_amount')).to eq false
+        expect(config.local_first_key?('number.my_currency.unit')).to eq false
+      end
+
+      it 'returns false for string-only number subtrees and non-number keys' do
+        expect(config.local_first_key?('number.human.storage_units.units.byte.one')).to eq false
+        expect(config.local_first_key?('date.formats.default')).to eq false
+        expect(config.local_first_key?('time.formats.short')).to eq false
+        expect(config.local_first_key?('datetime.distance_in_words.x')).to eq false
+        expect(config.local_first_key?('views.foo')).to eq false
+        expect(config.local_first_key?('numbers.foo')).to eq false
+      end
+
+      it 'keeps protecting built-in keys without breaking a user-set regexp' do
+        config.local_first_key_regexp = /\Aviews\./
+
+        expect(config.local_first_key?('number.currency.format')).to eq true
+        expect(config.local_first_key?('views.foo')).to eq true
+        expect(config.local_first_key?('models.foo')).to eq false
+      end
+    end
   end
 
   describe '#exclude_key_regexp= (deprecated)' do

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -445,7 +445,7 @@ describe 'CopyTunerClient::I18nBackend' do
     end
   end
 
-  describe 'local_first_key_regexp（ローカル優先キー）' do
+  describe 'local_first_key_regexp（ローカル優先キー）' do # rubocop:disable Metrics/BlockLength
     after { CopyTunerClient.configuration.local_first_key_regexp = nil }
 
     # ローカル config/locales 相当のデータを I18n::Backend::Simple 側だけに格納する。
@@ -467,6 +467,24 @@ describe 'CopyTunerClient::I18nBackend' do
         store_local(subject, :ja, views: { foo: 'local value' })
 
         expect(subject.translate('ja', 'views.foo')).to eq('copy tuner value')
+      end
+
+      # NOTE: number.*.format は precision 等の非文字列値が store_item で落ちるため、
+      # tree cache を優先するとローカル YAML の正しい format が壊れる。組み込み判定で常にローカル優先にする。
+      it 'number.*.format は cache に値があってもローカル YAML を優先すること' do
+        CopyTunerClient.configuration.local_first_key_regexp = nil
+        cache['ja.number.currency.format.unit'] = '$'
+        store_local(subject, :ja, number: { currency: { format: { unit: '円' } } })
+
+        expect(subject.translate('ja', 'number.currency.format')).to eq(unit: '円')
+      end
+
+      it 'アプリ独自の number キーは従来どおり copy_tuner を優先すること' do
+        CopyTunerClient.configuration.local_first_key_regexp = nil
+        cache['ja.number.gift_amount'] = 'copy tuner value'
+        store_local(subject, :ja, number: { gift_amount: 'local value' })
+
+        expect(subject.translate('ja', 'number.gift_amount')).to eq('copy tuner value')
       end
     end
 


### PR DESCRIPTION
<!-- pr-summary-start -->
## 背景・課題

copy_tuner_client 1.2.3 で `number_to_currency` などの数値フォーマットが壊れるリグレッションが発生していた（例: `800円` が `$800.00` になる）。

原因は 2 つの相互作用にある:

- CopyTuner の `store_item` は文字列値しか保持できず、`number.currency.format` 配下の `precision`（Integer）や `significant` / `strip_insignificant_zeros`（Boolean）といった非文字列値を捨ててしまう
- 1.2.3 で追加された `lookup_in_tree_cache` が CopyTuner の tree cache をローカル YAML より優先するため、precision 等を欠いた不完全な値でローカルの正しい設定を shadow してしまう

CopyTuner を経由する限り、非文字列値を含む format キーは構造的に正しく扱えない。そこでこれらのキーを gem 側で固定的にローカル YAML 優先（CopyTuner バイパス）にする。

## 変更内容

- **組み込みのローカル優先判定を新設**: `Configuration::BUILTIN_LOCAL_FIRST_KEY_REGEXP` と `Configuration.builtin_local_first_key?` を追加。`local_first_key_regexp` の設定有無にかかわらず、Rails 標準の `number.format` / `number.currency.format` / `number.percentage.format` / `number.human.format`（およびその配下）を常にローカル優先にする。
- **対象を Rails 標準の format サブツリーに限定**: 「number 全体」ではなく上記 4 つを明示列挙する選択をしている。Rails 本体の en.yml を確認し非文字列値が出現するのは `number.*.format` 配下のみと判明したため。これにより、アプリ独自の `number.gift_amount` のようなキーは対象外となり従来どおり CopyTuner で管理できる。正規表現の末尾 `(\.|\z)` で、ハッシュ lookup（`number.currency.format`）と葉キー（`number.currency.format.precision`）の両方にマッチさせている。
- **判定ロジックを 1 箇所に集約**: lookup 経路（`Configuration#local_first_key?`）とアップロード抑止経路（`Cache#[]=` 内の `local_first_key?`）の両方が `Configuration.builtin_local_first_key?` を共有する。経路ごとに個別ガードを置かず判定本体を Configuration に集約することで、将来 number 以外を追加する際の同期漏れ・付け忘れの穴を防ぐ設計にしている（プロジェクトの既存方針に沿う）。
- **ドキュメント追記**: README と skills/copy-tuner/SKILL.md に、この組み込みローカル優先の挙動とアプリ独自 number キーが対象外である点を追記。
- **テスト追加**: cache / configuration / i18n_backend の各 spec に、組み込みキーの抑止・優先と、アプリ独自 number キー・文字列のみのサブツリー（`number.human.storage_units.*`）・date/time 系が対象外であることのケースを追加。

## レビューのポイント

- **対象キーの列挙が過不足ないか**: 非文字列値を含むのが `number.*.format` 配下のみという前提（Rails 本体 en.yml の確認結果）に依存している。Rails のバージョン差や `number.human.storage_units` などの周辺キーで、ローカル優先にすべき / すべきでない境界が要件に合っているかドメイン観点での確認が望ましい。
- **挙動変更の互換性**: これまで `number.*.format` を CopyTuner 側で編集・管理していた利用者がいる場合、本変更でそのキーが lookup でバイパスされアップロードもされなくなる。リグレッション修正としては正しい方向だが、既存運用への影響周知が必要かどうか。
<!-- pr-summary-end -->
