### PR TITLE
[review] refactor: 1.3.0 で不要になった convert_value_type を削除

### DIFF
--- a/lib/copy_tuner_client/dotted_hash.rb
+++ b/lib/copy_tuner_client/dotted_hash.rb
@@ -3,9 +3,7 @@ module CopyTunerClient
     def to_h(dotted_hash)
       hash = {}
       dotted_hash.to_h.transform_keys(&:to_s).sort.each do |key, value|
-        # Rails i18n標準との互換性のため、特定のキーを適切な型に変換
-        converted_value = convert_value_type(key, value)
-        _hash = key.split('.').reverse.inject(converted_value) { |memo, _key| { _key => memo } }
+        _hash = key.split('.').reverse.inject(value) { |memo, _key| { _key => memo } }
         hash.deep_merge!(_hash)
       end
       hash
@@ -29,22 +27,6 @@ module CopyTunerClient
       results
     end
 
-    private
-
-    def convert_value_type(key, value)
-      return value unless value.is_a?(String)
-
-      # Rails i18n標準で数値型として扱われるキー
-      if key.end_with?('.precision')
-        value.to_i
-      # Rails i18n標準で真偽値として扱われるキー
-      elsif key.end_with?('.significant', '.strip_insignificant_zeros')
-        value == 'true'
-      else
-        value
-      end
-    end
-
-    module_function :to_h, :conflict_keys, :convert_value_type # rubocop:disable Style/AccessModifierDeclarations
+    module_function :to_h, :conflict_keys # rubocop:disable Style/AccessModifierDeclarations
   end
 end

--- a/spec/copy_tuner_client/dotted_hash_spec.rb
+++ b/spec/copy_tuner_client/dotted_hash_spec.rb
@@ -59,75 +59,22 @@ describe CopyTunerClient::DottedHash do
       it { is_expected.to eq({ 'en' => { 'test' => { 'key' => 'en test value' } } }) }
     end
 
-    context "Rails i18nの数値precisionキーの場合" do
+    # NOTE: number.*.format 配下のキー（precision 等）は I18nBackend の local_first_key? ガードで
+    # tree_cache をバイパスしローカル YAML 優先になるため、ここで型変換せず文字列のまま保持する。
+    # （number_to_currency が壊れないことは i18n_backend_spec の number ローカル優先テストで担保）
+    context "number.*.format 配下の値を含む場合" do
       let(:dotted_hash) do
         {
           'en.number.currency.format.precision' => '2',
-          'en.number.format.precision' => '3',
-        }
-      end
-
-      it "precision値を整数に変換する" do
-        is_expected.to eq({
-          'en' => {
-            'number' => {
-              'currency' => {
-                'format' => {
-                  'precision' => 2,
-                },
-              },
-              'format' => {
-                'precision' => 3,
-              },
-            },
-          },
-        })
-      end
-    end
-
-    context "Rails i18nのbooleanキーの場合" do
-      let(:dotted_hash) do
-        {
-          'en.number.currency.format.significant' => 'false',
-          'en.number.format.strip_insignificant_zeros' => 'true',
-        }
-      end
-
-      it "boolean値を実際の真偽値に変換する" do
-        is_expected.to eq({
-          'en' => {
-            'number' => {
-              'currency' => {
-                'format' => {
-                  'significant' => false,
-                },
-              },
-              'format' => {
-                'strip_insignificant_zeros' => true,
-              },
-            },
-          },
-        })
-      end
-    end
-
-    context "Rails i18n以外で似たパターンを含むキーの場合" do
-      let(:dotted_hash) do
-        {
           'en.custom.precision' => 'custom_value',
-          'en.other.significant_value' => 'true',
         }
       end
 
-      it "Rails i18nパターンで終わるキーのみ変換する" do
+      it "型変換せず値を文字列のまま保持する" do
         is_expected.to eq({
           'en' => {
-            'custom' => {
-              'precision' => 0, # .precision suffix triggers conversion
-            },
-            'other' => {
-              'significant_value' => 'true', # no conversion for non-exact match
-            },
+            'number' => { 'currency' => { 'format' => { 'precision' => '2' } } },
+            'custom' => { 'precision' => 'custom_value' },
           },
         })
       end


### PR DESCRIPTION
<!-- pr-summary-start -->
## 背景・課題

CopyTuner 1.2.3 で `number_to_currency` などが壊れる（800円 が $800.00 になる）リグレッションがあり、直前の PR #117 で「Rails 標準の `number.*.format` 配下キーを常にローカル YAML 優先（CopyTuner バイパス）にする」対応が入った。

`DottedHash#to_h` の `convert_value_type` は、CopyTuner サーバから文字列で返ってくる `precision`（整数）/ `significant`・`strip_insignificant_zeros`（真偽値）を Rails i18n 標準が期待する型へ変換する処理だった。これは「CopyTuner 経由でも format キーを正しく扱う」ために導入されたもの。

しかし PR #117 で `number.*.format` 配下のキーは `I18nBackend` の `local_first_key?` ガードにより tree_cache をバイパスしてローカル YAML が直接参照されるようになった。これらのキーが CopyTuner 経由の値を使わなくなったため、`convert_value_type` による型変換はもう不要になった。本 PR はこの不要になったコードを撤去する後始末（リファクタ）。

## 変更内容

- `DottedHash#to_h` から `convert_value_type` を削除（`lib/copy_tuner_client/dotted_hash.rb`）。`precision` / `significant` / `strip_insignificant_zeros` で終わるキーの型変換をやめ、値を文字列のまま tree へ格納する。`module_function` の公開対象からも除外。
- 対応する spec を新しい挙動（文字列のまま保持）へ更新（`spec/copy_tuner_client/dotted_hash_spec.rb`）。型変換を検証していた 3 つの context を、文字列のまま保持されることを確認する 1 つの context に統合。
- 削除した型変換が不要である根拠（`local_first_key?` ガードで実際の `number_to_currency` の正しさは `i18n_backend_spec` の number ローカル優先テストが担保していること）をコード内 NOTE コメントに残し、将来「なぜ変換しないのか」を辿れるようにした。

なぜ「機能追加（PR #117）と同時ではなく別 PR で削除」したか: PR #117 はリグレッション修正というユーザー影響のある変更で、本 PR は振る舞いを変えない後片付けのため、レビュー単位を分離している。

## レビューのポイント

- `number.*.format` 以外で `.precision` / `.significant` / `.strip_insignificant_zeros` で終わるキーを CopyTuner 経由で管理しているアプリが存在しないか。従来はそうしたキーも `convert_value_type` で型変換されていた（例: アプリ独自の `custom.precision` も整数 `0` に変換されていた）。この変更後は文字列のまま保持されるため、もし型変換に依存していたアプリがあれば挙動が変わる。`local_first` 対象は Rails 標準の format サブツリーのみで、それ以外の `number.*` 等はバイパスされない点に注意。
- `convert_value_type` が `DottedHash` の外部（他 gem / アプリ）から参照されていないか。`module_function` で公開されていたため、念のため確認したい。
<!-- pr-summary-end -->
