### PR TITLE
docs: copy-tuner スキルに MCP 経由探索の徹底と既存キー更新手順を追記

### DIFF
--- a/skills/copy-tuner/SKILL.md
+++ b/skills/copy-tuner/SKILL.md
@@ -18,12 +18,18 @@ license: MIT
 | 判別 | 管理場所 | 操作 |
 |---|---|---|
 | マッチする | config/locales（copy_tuner と完全分離） | `config/locales/*.yml` を Read / Edit |
-| マッチしない・未設定 | copy_tuner | MCP ツール（下記） |
+| マッチしない・未設定 | copy_tuner | **MCP ツール経由でのみ探す**（下記） |
+
+**copy_tuner 管理のキーは必ず MCP ツール経由で探すこと。** ローカルの `.yml` を grep して見つけたつもりになってはならない。
 
 **例外（gem 組み込み・設定不要で常に config/locales 管理）:** Rails 標準の `number.format` /
 `number.currency.format` / `number.percentage.format` / `number.human.format`（およびその配下）。
 `precision` 等の非文字列値を含み copy_tuner では正しく扱えないため、gem が常にバイパスする。
 これらは `config/locales/*.yml` を見る・編集すること（アプリ独自の `number.gift_amount` 等は対象外で通常どおり copy_tuner）。
+
+**`config/locales` 以外の export 済み yml は参照禁止:**
+環境によっては copy_tuner から export したキャッシュ用の `.yml`（`config/locales` 配下以外、例: アプリ直下や `tmp/`、`db/` などに置かれた export ファイル）が存在することがある。
+これらは古いスナップショットであり権威ある情報源ではない。**読んで判断材料にしてはならない。** copy_tuner 管理キーは常に MCP ツールで最新を確認する。
 
 **config/locales 管理キーの落とし穴:**
 - copy_tuner には存在しないので、MCP ツールで探しても見つからない。`config/locales` を見ること。
@@ -38,13 +44,27 @@ license: MIT
 | キー名（一部）から翻訳を調べる | `search_key`（引数は英語キーワード） |
 | 画面テキストからキーを逆引き | `search_translations` |
 | 新しいキーを登録する | `create_i18n_key` |
-| 既存キーの翻訳を更新する | `get_edit_url`（ブラウザ編集） |
+| 既存キーのドラフト訳を更新する | `update_i18n_key` |
+| 既存キーの翻訳を更新する（ブラウザ） | `get_edit_url` |
 | 使用中ロケールを確認 | `get_locales` |
 
 ## 新規キー登録
 
 1. `search_key` で関連キーを検索し、既存の命名パターンに合わせる（例: `search_key("move_out")`）。
 2. ja は必須。他は `get_locales` で確認し、存在するロケール分を登録する。
+
+## 既存キーの訳を更新する
+
+`update_i18n_key` を使う。`key` と `translations`（ロケール・値のペア配列）は両方必須。
+
+**制約**: ドラフト状態または未発行のキーのみ更新可能。発行済み（published）かどうかを事前に知る手段はなく、API にリクエストしてエラーが返るかどうかで初めてわかる。
+
+**published キーへの対応方針**: 値を直接書き換えるのはリスクが高いため、原則として以下の手順を推奨する:
+1. 新しいキーにバージョン番号を付けて登録する（例: `views.foo_v2`）→ **新規キー登録の手順に従う**
+2. コード側の参照を新キーに差し替える
+3. 古いキーを `config/initializers/copy_tuner.rb` の `ignored_keys` に追加する
+
+どうしても既存キーを書き換えたい場合は `get_edit_url` でブラウザから編集する。
 
 ## 不要なキーの処理
 


### PR DESCRIPTION
copy_tuner サーバリポジトリ側 SKILL.md で先行していた記述を取り込み、両リポジトリのスキル内容を揃える。

- copy_tuner 管理キーはローカル `.yml` の grep でなく MCP 経由でのみ探す旨を強調
- `config/locales` 配下以外の export 済み yml は古いスナップショットのため参照禁止と明記
- `update_i18n_key` によるドラフト訳更新と published キーへの対応方針セクションを追加（ruby-client 固有の `number.*.format` 例外説明は維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)