### PR TITLE
[review] feat: Copyray マーカーを HTML レスポンス描画時のみ注入する

### DIFF
--- a/lib/copy_tuner_client/helper_extension.rb
+++ b/lib/copy_tuner_client/helper_extension.rb
@@ -10,6 +10,11 @@ module CopyTunerClient
               return source
             end
 
+            # NOTE: マーカー注入は最終的に Rack を通って CopyrayMiddleware で除去される HTML レスポンスの
+            # 描画のときだけ行う。メール本文・render :json・CSV/PDF など非 HTML 経路では除去されず
+            # コメントが残るため、それらの経路には注入しない。
+            return source unless copyray_injectable?
+
             # TODO: test
             # NOTE: default引数が設定されている場合は、copytunerキャッシュの値をI18n.t呼び出しにより上書きしている
             # SEE: https://github.com/rails/rails/blob/6c43ebc220428ce9fc9569c2e5df90a38a4fc4e4/actionview/lib/action_view/helpers/translation_helper.rb#L82
@@ -32,6 +37,23 @@ module CopyTunerClient
               CopyTunerClient::Copyray.augment_template(source, scope_key)
             end
           end
+
+          # NOTE: 描画中のフォーマットが HTML で、かつ mailer 以外の描画文脈のときだけ true。
+          # @current_template.format が描画中テンプレートのフォーマットを最も正確に表す。
+          # render html: 等で @current_template が nil のときは lookup_context.formats.first にフォールバック。
+          def copyray_injectable?
+            format = @current_template&.format || lookup_context.formats.first
+            return false unless format == :html
+
+            # NOTE: mailer の HTML パートも format は :html になるため format 判定だけでは除外できない。明示除外する。
+            current_controller = controller
+            return false if current_controller.nil?
+            return false if defined?(ActionMailer::Base) && current_controller.is_a?(ActionMailer::Base)
+
+            true
+          end
+          private :copyray_injectable?
+
           if middleware_enabled
             alias_method :translate_without_copyray_comment, :translate
             alias_method :translate, :translate_with_copyray_comment

--- a/lib/copy_tuner_client/helper_extension.rb
+++ b/lib/copy_tuner_client/helper_extension.rb
@@ -10,17 +10,18 @@ module CopyTunerClient
               return source
             end
 
-            # NOTE: マーカー注入は最終的に Rack を通って CopyrayMiddleware で除去される HTML レスポンスの
-            # 描画のときだけ行う。メール本文・render :json・CSV/PDF など非 HTML 経路では除去されず
-            # コメントが残るため、それらの経路には注入しない。
-            return source unless copyray_injectable?
-
             # TODO: test
             # NOTE: default引数が設定されている場合は、copytunerキャッシュの値をI18n.t呼び出しにより上書きしている
             # SEE: https://github.com/rails/rails/blob/6c43ebc220428ce9fc9569c2e5df90a38a4fc4e4/actionview/lib/action_view/helpers/translation_helper.rb#L82
             if options.key?(:default)
               I18n.t(key.to_s.first == '.' ? scope_key_by_partial(key) : key, **options)
             end
+
+            # NOTE: マーカーは HTML コメントとしてブラウザに無視されつつ Copyray オーバーレイのキー特定に
+            # 使われる。HTML 以外の経路（メール本文・render :json・CSV/PDF など）ではコメントが文字列として
+            # 出力に混入してしまうため、それらの経路には注入しない。default 引数による初期値登録は維持する
+            # 必要があるため、このガードは初期値登録（上の I18n.t 呼び出し）より後に置く。
+            return source unless copyray_injectable?
 
             if CopyTunerClient.configuration.disable_copyray_comment_injection
               source
@@ -38,8 +39,7 @@ module CopyTunerClient
             end
           end
 
-          # NOTE: 描画中のフォーマットが HTML で、かつ mailer 以外の描画文脈のときだけ true。
-          # @current_template.format が描画中テンプレートのフォーマットを最も正確に表す。
+          # NOTE: @current_template.format が描画中テンプレートのフォーマットを最も正確に表す。
           # render html: 等で @current_template が nil のときは lookup_context.formats.first にフォールバック。
           def copyray_injectable?
             format = @current_template&.format || lookup_context.formats.first

--- a/lib/copy_tuner_client/helper_extension.rb
+++ b/lib/copy_tuner_client/helper_extension.rb
@@ -39,18 +39,20 @@ module CopyTunerClient
             end
           end
 
-          # NOTE: @current_template.format が描画中テンプレートのフォーマットを最も正確に表す。
-          # render html: 等で @current_template が nil のときは lookup_context.formats.first にフォールバック。
+          # NOTE: HTML 以外の経路（メール本文・render :json・CSV/PDF など）ではマーカーが文字列として
+          # 出力に混入するため注入しない。判定には controller.request.format を使い、@current_template.format /
+          # lookup_context.formats のような ActionView の内部実装には依存させない（Rails バージョン間で壊れうるため）。
           def copyray_injectable?
-            format = @current_template&.format || lookup_context.formats.first
-            return false unless format == :html
-
-            # NOTE: mailer の HTML パートも format は :html になるため format 判定だけでは除外できない。明示除外する。
             current_controller = controller
             return false if current_controller.nil?
+
+            # NOTE: mailer は request を持たず request.format で判定できない。かつメール本文への
+            # マーカー混入は実害が大きいため、controller の型で明示除外する。
             return false if defined?(ActionMailer::Base) && current_controller.is_a?(ActionMailer::Base)
 
-            true
+            # NOTE: request が無い／format が html でない経路には注入しない。&. と || false で
+            # request 不在時も安全に false を返す。
+            current_controller.request&.format&.html? || false
           end
           private :copyray_injectable?
 

--- a/spec/copy_tuner_client/helper_extension_spec.rb
+++ b/spec/copy_tuner_client/helper_extension_spec.rb
@@ -64,7 +64,6 @@ describe CopyTunerClient::HelperExtension do
 
   context 'injection guard by rendering context' do
     it 'injects the marker when the template format is :html' do
-      view.current_template = Template.new(:html)
       expect(view.translate('some.key', name: 'World')).to eq '<!--COPYRAY some.key-->Hello, World'
     end
 
@@ -99,6 +98,16 @@ describe CopyTunerClient::HelperExtension do
       view.current_template = Template.new(:html)
       view.controller = Object.new
       expect { view.translate('some.key', name: 'World') }.not_to raise_error
+    end
+  end
+
+  # NOTE: マーカー注入を抑止する非 HTML 経路でも、default 引数による初期値登録（I18n.t 呼び出し）は
+  # 維持されなければならない。注入ガードが初期値登録まで巻き添えで止めていないことを保証する。
+  context 'default value registration' do
+    it 'registers the default value even when the marker is not injected' do
+      view.current_template = Template.new(:json)
+      expect(I18n).to receive(:t).with('some.key', hash_including(default: 'Default'))
+      view.translate('some.key', name: 'World', default: 'Default')
     end
   end
 end

--- a/spec/copy_tuner_client/helper_extension_spec.rb
+++ b/spec/copy_tuner_client/helper_extension_spec.rb
@@ -3,13 +3,38 @@ require 'copy_tuner_client/helper_extension'
 require 'copy_tuner_client/copyray'
 
 describe CopyTunerClient::HelperExtension do
+  # NOTE: helper_extension が参照する CopyTunerClient::Rails は engine への依存があり
+  # 単体 spec では require できないため、メソッドをスタブできる最小の入れ物だけ用意する。
+  module CopyTunerClient
+    module Rails
+      def self.controller_of_rails_engine?(_controller)
+        false
+      end
+    end
+  end
+
+  # NOTE: format / controller を差し替えられる最小のフェイクビュー。
+  # @current_template.format と lookup_context.formats.first で描画フォーマットを、
+  # controller で mailer 判定を再現する。
+  Template = Struct.new(:format)
+  LookupContext = Struct.new(:formats)
+
   module KeywordArgumentsHelper
+    attr_writer :current_template, :lookup_context, :controller
+
     def translate(key, **options)
       "Hello, #{options[:name]}"
     end
 
+    def lookup_context
+      @lookup_context ||= LookupContext.new([:html])
+    end
+
     def controller
-      nil
+      return @controller if defined?(@controller)
+
+      # NOTE: 実 HTML 描画では controller が存在するため、デフォルトは非 nil の素のオブジェクト。
+      @controller = Object.new
     end
   end
 
@@ -19,14 +44,61 @@ describe CopyTunerClient::HelperExtension do
 
   CopyTunerClient::HelperExtension.hook_translation_helper(KeywordArgumentsHelper, middleware_enabled: true)
 
+  let(:view) { KeywordArgumentsView.new }
+
+  before do
+    view.current_template = Template.new(:html)
+    # NOTE: controller_of_rails_engine? は ::Rails::Engine への依存があり単体 spec では評価できないため、
+    # この spec の関心（注入ガード）に絞って常に false を返すようスタブする。
+    allow(CopyTunerClient::Rails).to receive(:controller_of_rails_engine?).and_return(false)
+  end
+
   it 'works with keyword argument method' do
-    view = KeywordArgumentsView.new
     expect(view.translate('some.key', name: 'World')).to eq '<!--COPYRAY some.key-->Hello, World'
   end
 
   it 'does not inject the overlay marker for a local_first key' do
     CopyTunerClient.configuration.local_first_key_regexp = /\Aviews\./
-    view = KeywordArgumentsView.new
     expect(view.translate('views.foo', name: 'World')).to eq 'Hello, World'
+  end
+
+  context 'injection guard by rendering context' do
+    it 'injects the marker when the template format is :html' do
+      view.current_template = Template.new(:html)
+      expect(view.translate('some.key', name: 'World')).to eq '<!--COPYRAY some.key-->Hello, World'
+    end
+
+    it 'falls back to lookup_context.formats.first when @current_template is nil' do
+      view.current_template = nil
+      view.lookup_context = LookupContext.new([:html])
+      expect(view.translate('some.key', name: 'World')).to eq '<!--COPYRAY some.key-->Hello, World'
+    end
+
+    %i[json text csv pdf].each do |format|
+      it "does not inject the marker when the template format is :#{format}" do
+        view.current_template = Template.new(format)
+        expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
+      end
+    end
+
+    it 'does not inject the marker when rendered by a mailer' do
+      stub_const('ActionMailer::Base', Class.new)
+      view.current_template = Template.new(:html)
+      view.controller = ActionMailer::Base.new
+      expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
+    end
+
+    it 'does not inject the marker when controller is nil' do
+      view.current_template = Template.new(:html)
+      view.controller = nil
+      expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
+    end
+
+    it 'does not raise when ActionMailer is not loaded' do
+      hide_const('ActionMailer::Base') if defined?(ActionMailer::Base)
+      view.current_template = Template.new(:html)
+      view.controller = Object.new
+      expect { view.translate('some.key', name: 'World') }.not_to raise_error
+    end
   end
 end

--- a/spec/copy_tuner_client/helper_extension_spec.rb
+++ b/spec/copy_tuner_client/helper_extension_spec.rb
@@ -13,28 +13,29 @@ describe CopyTunerClient::HelperExtension do
     end
   end
 
-  # NOTE: format / controller を差し替えられる最小のフェイクビュー。
-  # @current_template.format と lookup_context.formats.first で描画フォーマットを、
-  # controller で mailer 判定を再現する。
-  Template = Struct.new(:format)
-  LookupContext = Struct.new(:formats)
+  # NOTE: request.format で描画フォーマットを判定するため、format を差し替えられる
+  # 最小のフェイク request / controller を用意する。mailer 判定は controller の型で行う。
+  Format = Struct.new(:type) do
+    def html?
+      type == :html
+    end
+  end
+  Request = Struct.new(:format)
+  Controller = Struct.new(:request)
 
   module KeywordArgumentsHelper
-    attr_writer :current_template, :lookup_context, :controller
+    attr_writer :controller
 
     def translate(key, **options)
       "Hello, #{options[:name]}"
     end
 
-    def lookup_context
-      @lookup_context ||= LookupContext.new([:html])
-    end
-
     def controller
       return @controller if defined?(@controller)
 
-      # NOTE: 実 HTML 描画では controller が存在するため、デフォルトは非 nil の素のオブジェクト。
-      @controller = Object.new
+      # NOTE: 実 HTML 描画では controller が存在し request.format が html になるため、
+      # デフォルトはそれを再現した controller。
+      @controller = Controller.new(Request.new(Format.new(:html)))
     end
   end
 
@@ -47,7 +48,6 @@ describe CopyTunerClient::HelperExtension do
   let(:view) { KeywordArgumentsView.new }
 
   before do
-    view.current_template = Template.new(:html)
     # NOTE: controller_of_rails_engine? は ::Rails::Engine への依存があり単体 spec では評価できないため、
     # この spec の関心（注入ガード）に絞って常に false を返すようスタブする。
     allow(CopyTunerClient::Rails).to receive(:controller_of_rails_engine?).and_return(false)
@@ -62,41 +62,39 @@ describe CopyTunerClient::HelperExtension do
     expect(view.translate('views.foo', name: 'World')).to eq 'Hello, World'
   end
 
-  context 'injection guard by rendering context' do
-    it 'injects the marker when the template format is :html' do
-      expect(view.translate('some.key', name: 'World')).to eq '<!--COPYRAY some.key-->Hello, World'
-    end
-
-    it 'falls back to lookup_context.formats.first when @current_template is nil' do
-      view.current_template = nil
-      view.lookup_context = LookupContext.new([:html])
+  context 'injection guard by request format' do
+    it 'injects the marker when request.format is html' do
       expect(view.translate('some.key', name: 'World')).to eq '<!--COPYRAY some.key-->Hello, World'
     end
 
     %i[json text csv pdf].each do |format|
-      it "does not inject the marker when the template format is :#{format}" do
-        view.current_template = Template.new(format)
+      it "does not inject the marker when request.format is :#{format}" do
+        view.controller = Controller.new(Request.new(Format.new(format)))
         expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
       end
     end
+  end
 
+  context 'injection guard by controller' do
     it 'does not inject the marker when rendered by a mailer' do
       stub_const('ActionMailer::Base', Class.new)
-      view.current_template = Template.new(:html)
       view.controller = ActionMailer::Base.new
       expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
     end
 
     it 'does not inject the marker when controller is nil' do
-      view.current_template = Template.new(:html)
       view.controller = nil
+      expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
+    end
+
+    it 'does not inject the marker when the controller has no request' do
+      view.controller = Controller.new(nil)
       expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
     end
 
     it 'does not raise when ActionMailer is not loaded' do
       hide_const('ActionMailer::Base') if defined?(ActionMailer::Base)
-      view.current_template = Template.new(:html)
-      view.controller = Object.new
+      view.controller = Controller.new(Request.new(Format.new(:html)))
       expect { view.translate('some.key', name: 'World') }.not_to raise_error
     end
   end
@@ -105,7 +103,7 @@ describe CopyTunerClient::HelperExtension do
   # 維持されなければならない。注入ガードが初期値登録まで巻き添えで止めていないことを保証する。
   context 'default value registration' do
     it 'registers the default value even when the marker is not injected' do
-      view.current_template = Template.new(:json)
+      view.controller = Controller.new(Request.new(Format.new(:json)))
       expect(I18n).to receive(:t).with('some.key', hash_including(default: 'Default'))
       view.translate('some.key', name: 'World', default: 'Default')
     end


### PR DESCRIPTION
<!-- pr-summary-start -->
## 背景・課題

開発環境で Copyray オーバーレイを実現するため、`translate` ヘルパーは i18n 値に `<!--COPYRAY key-->` というマーカーコメントを注入する。フロント（`src/copyray.ts`）はこのコメントを DOM 上で走査して「どの要素がどのキーか」を特定する。

しかし注入は `translate` 呼び出しのたびに無条件で発火していた。HTML ページではコメントはブラウザに無視されオーバーレイに使われるだけで無害だが、`translate` は HTML 以外のレスポンス描画でも発火するため、そうした経路ではコメントが文字列として出力にそのまま混入してしまう。具体的には次の非 HTML 経路が該当する:

- ActionMailer のメール本文
- `render :json`（JSON 値の中にコメントが混入）
- CSV / PDF / テキストなど HTML 以外のレスポンス

これらは `CopyrayMiddleware` を通らないためマーカーが除去されず、開発環境でメール本文や JSON レスポンスに `<!--COPYRAY-->` が混ざる。本 PR はこの穴を塞ぐ。

## 変更内容

- `helper_extension.rb` に `copyray_injectable?` ガードを追加し、HTML 描画かつ mailer 以外の文脈のときだけマーカーを注入するようにした。それ以外の経路では元の文字列をそのまま返す。
- **フォーマット判定は `controller.request.format.html?` で行う。** 当初は `@current_template.format` 優先・`lookup_context.formats.first` フォールバックという ActionView 内部実装ベースの実装だったが、これらは Rails バージョン間で壊れうるとのレビュー指摘を受け、`request.format` ベースに置き換えた。`render html:` で `@current_template` が nil になるケースも `request.format` なら自然に html 判定でき、フォールバック分岐自体が不要になった。
- **mailer の明示除外**: mailer は `request` を持たず `request.format` で判定できない。かつメール本文へのマーカー混入は実害が大きいため、controller が `ActionMailer::Base` のインスタンスかどうかで明示的に除外する。controller が nil の場合・request が無い場合も注入しない。
- `ActionMailer` が未ロードの環境でも例外を出さないよう、`defined?(ActionMailer::Base)` でガードしてから型判定している。
- **default 引数による初期値登録は維持する。** ガードを `:default` ブロックより手前に置いた初期実装では、非 HTML 経路でマーカー注入だけでなく default 引数による初期値登録（`I18n.t` 呼び出し）まで巻き添えでスキップされる回帰があった。ガードを初期値登録より後ろへ移動し、注入のみを抑止するよう修正済み。
- spec は注入ガードのケースを網羅追加（html 注入 / json・text・csv・pdf 非注入 / mailer 非注入 / controller nil / request 無し / ActionMailer 未ロード時に例外を出さない / 非 HTML 経路でも default 初期値登録は維持）。

## レビューのポイント

- **`request.format.html?` での判定が実運用の描画経路を取りこぼさないか**: partial / layout / `render html:` / `render plain:` 等で `request.format` が期待どおり html / 非 html を返すか。特に format が明示されないリクエストでの既定フォーマットの扱い。
- **mailer 判定の前提**: mailer を「controller が `ActionMailer::Base` のインスタンス」で識別している。アプリ側のメーラーが `ActionMailer::Base` を継承している前提が常に成り立つか（`ActionMailer::Base` を直接継承しない構成の有無）。
<!-- pr-summary-end -->