### PR TITLE
[review] feat!: v2 で非推奨機能を削除する（exclude_key_regexp 削除・project_id 必須化）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+- **【後方互換性に影響】** `config.exclude_key_regexp` を削除しました。後継の `config.local_first_key_regexp`
+  を使ってください。両者は対象キーの形式が異なります（`exclude_key_regexp` は locale 付き `ja.views.foo`、
+  `local_first_key_regexp` は locale を除いた `views.foo`）。正規表現から locale プレフィックスを外して
+  移行してください。挙動も異なり、`local_first_key_regexp` は lookup 時に CopyTuner キャッシュをスキップして
+  ローカル YAML を優先します（完全分離）。
+- **【後方互換性に影響】** `config.project_id` を必須にしました。未設定のまま `configure`（`apply`）すると
+  `ArgumentError: project_id is required` で失敗します。これまで `project_id` 未設定時は `api_key` へ
+  フォールバックして deprecation 警告を出していましたが、このフォールバックは削除しました。initializer に
+  `config.project_id = <プロジェクト ID>` を設定してください。
 - Copyray オーバーレイのマーカー方式を刷新。訳文への HTML コメント `<!--COPYRAY key-->` 注入をやめ、
   可視トークン `⟦CT:key⟧` を埋め込んだうえで `CopyrayMiddleware` が `data-copyray-key` 属性に変換し、
   トークンを HTML から完全に除去するようになりました。最終配信 HTML にコメント・トークンは残りません。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,7 @@ Rails 統合は engine.rb のイニシャライザ経由（ヘルパー/SimpleFo
 ## Gotchas
 - **フロントエンドは `src/*.ts` を編集する。`app/assets/*` は Vite のビルド成果物なので直接編集しない**
   （vite.config.ts が `src/main.ts` → `app/assets/javascripts/copytuner.js` を出力）。
-- キー除外の 2 オプションは混同しやすい:
-  - `exclude_key_regexp` — locale 付きキー対象・アップロード時に作用
-  - `local_first_key_regexp` — locale を除いたキー対象・lookup 時に作用（ローカル YAML 優先）
+- `local_first_key_regexp` — locale を除いたキー対象・lookup 時に作用（ローカル YAML 優先）。
   local_first キーのアップロード抑止は `Cache#[]=` に集約されている。
 - **アップロード抑止の新ルールは `Cache#[]=` に足す。`I18nBackend` の書き込み経路（`lookup` / `default` / `store_item`）ごとに個別ガードを足さない**
   （理由: cache への書き込みは全経路が最終的に `Cache#[]=` を通る単一の関門。経路ごとにガードを足すと付け忘れの穴が生まれ、同じチェックが分散して保守負担になる。実際 local_first の抑止は当初 `default` 個別に足したが穴が残り、`Cache#[]=` への集約に作り直した）。

--- a/README.md
+++ b/README.md
@@ -62,30 +62,6 @@ CopyTuner で一元管理している翻訳を、`views.*` のような単位で
 
 アプリ独自の `number.*` キー（例 `number.gift_amount`）は対象外で、従来どおり CopyTuner で管理できます。
 
-`exclude_key_regexp` との違い:
-
-| オプション | 対象 | 作用するタイミング |
-| --- | --- | --- |
-| `exclude_key_regexp` | locale 付きキー（例 `ja.views.foo`） | アップロード時（CopyTuner への送信を抑止） |
-| `local_first_key_regexp` | locale を除いたキー（例 `views.foo`） | 読み込み時（lookup の優先順位） |
-
-### `exclude_key_regexp` は非推奨です
-
-`exclude_key_regexp` は **非推奨**です（将来のリリースで削除予定）。設定すると deprecation 警告が出ます。代わりに `local_first_key_regexp` を使ってください。
-
-```ruby
-# Before（非推奨）
-config.exclude_key_regexp = /\Aja\.views\./
-
-# After: locale プレフィックス（ja.）を外して指定する
-config.local_first_key_regexp = /\Aviews\./
-```
-
-移行時の注意:
-
-- 対象キーの形式が異なります。`exclude_key_regexp` は **locale 付き**（`ja.views.foo`）、`local_first_key_regexp` は **locale を除いた**形式（`views.foo`）でマッチします。正規表現から locale プレフィックスを外してください。
-- 挙動も少し変わります。`exclude_key_regexp` はアップロードを抑止するだけで lookup 時は CopyTuner キャッシュを参照し続けますが、`local_first_key_regexp` は lookup 時に CopyTuner キャッシュをスキップしてローカル YAML を優先します（完全分離）。ローカル管理へ移行する用途では `local_first_key_regexp` のほうが適切です。
-
 ## Claude Code スキル
 
 `skills/copy-tuner/` に Claude Code 向けのスキルが含まれています。

--- a/lib/copy_tuner_client/cache.rb
+++ b/lib/copy_tuner_client/cache.rb
@@ -20,7 +20,6 @@ module CopyTunerClient
       @client = client
       @logger = options[:logger]
       @mutex = Mutex.new
-      @exclude_key_regexp = options[:exclude_key_regexp]
       @local_first_key_regexp = options[:local_first_key_regexp]
       @upload_disabled = options[:upload_disabled]
       @ignored_keys = options.fetch(:ignored_keys, [])
@@ -49,7 +48,6 @@ module CopyTunerClient
     # @param key [String] the key of the blurb to update
     # @param value [String] the new contents of the blurb
     def []=(key, value)
-      return if @exclude_key_regexp && key.match?(@exclude_key_regexp)
       return unless key.include?('.')
       return if @locales.present? && !@locales.member?(key.split('.').first)
       return if @upload_disabled

--- a/lib/copy_tuner_client/configuration.rb
+++ b/lib/copy_tuner_client/configuration.rb
@@ -18,7 +18,7 @@ module CopyTunerClient
                  proxy_port proxy_user secure polling_delay sync_interval
                  sync_interval_staging sync_ignore_path_regex logger
                  framework middleware disable_middleware disable_test_translation
-                 ca_file exclude_key_regexp local_first_key_regexp s3_host locales ignored_keys ignored_key_handler
+                 ca_file local_first_key_regexp s3_host locales ignored_keys ignored_key_handler
                  download_cache_dir].freeze
 
     # NOTE: Rails 標準ロケールで非文字列値（precision: Integer, significant: Boolean,
@@ -129,10 +129,6 @@ module CopyTunerClient
     attr_accessor :client
 
     attr_accessor :poller
-
-    # @return [Regexp] Regular expression to exclude keys.
-    # @deprecated Use {#local_first_key_regexp} instead.
-    attr_reader :exclude_key_regexp
 
     # @return [Regexp] Keys (without locale) matching this regexp bypass the
     #   copy_tuner cache and are looked up from local config/locales
@@ -333,18 +329,6 @@ module CopyTunerClient
       raise ArgumentError, 'api_key is required' if api_key.nil? || api_key.empty?
 
       @api_key = api_key
-    end
-
-    # @deprecated Use {#local_first_key_regexp} instead.
-    def exclude_key_regexp=(value)
-      unless value.nil?
-        ActiveSupport::Deprecation.new.warn(
-          'exclude_key_regexp is deprecated and will be removed in a future release. ' \
-          'Use local_first_key_regexp instead (note: it matches keys WITHOUT the locale prefix, ' \
-          'e.g. /\Aviews\./ instead of /\Aja\.views\./).'
-        )
-      end
-      @exclude_key_regexp = value
     end
 
     # Sync interval for Rack Middleware

--- a/lib/copy_tuner_client/configuration.rb
+++ b/lib/copy_tuner_client/configuration.rb
@@ -253,6 +253,9 @@ module CopyTunerClient
     #
     # When {#test?} returns +false+, the poller will be started.
     def apply # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      # NOTE: project_id は必須。未設定なら apply 時点で明示的に失敗させる
+      validate_project_id!
+
       self.locales ||= self.locales = if defined?(::Rails)
                                         ::Rails.application.config.i18n.available_locales.presence || Array(::Rails.application.config.i18n.default_locale)
                                       else
@@ -340,16 +343,11 @@ module CopyTunerClient
       end
     end
 
-    # @return [String] current project url by api_key
+    # @return [String] current project url by project_id
     def project_url
-      path =
-        if project_id
-          "/projects/#{project_id}"
-        else
-          ActiveSupport::Deprecation.new.warn('Please set project_id.')
-          "/projects/#{api_key}"
-        end
+      validate_project_id!
 
+      path = "/projects/#{project_id}"
       URI::Generic.build(scheme: self.protocol, host: self.host, port: self.port.to_i, path:).to_s
     end
 
@@ -370,6 +368,12 @@ module CopyTunerClient
     end
 
     private
+
+    # project_id は必須。未設定なら明示的に失敗させる。
+    # apply（起動時の全体検証）と project_url（apply を経ない経路へのセーフネット）の両方から呼ぶ。
+    def validate_project_id!
+      raise ArgumentError, 'project_id is required' if project_id.nil?
+    end
 
     def default_port
       if secure?

--- a/skills/copy-tuner-to-locales-migrate-prefix/references/local-first-regexp.md
+++ b/skills/copy-tuner-to-locales-migrate-prefix/references/local-first-regexp.md
@@ -60,13 +60,8 @@ config.local_first_key_regexp = Regexp.union(
 （`/\Aviews\./`。`Regexp.union` に文字列を渡す場合は自動エスケープされるが、Regexp リテラルを渡すときは自分で
 書く）。
 
-## deprecated な exclude_key_regexp との違い
+## 旧 exclude_key_regexp について
 
-| | `local_first_key_regexp` | `exclude_key_regexp`（非推奨） |
-|---|---|---|
-| 対象キー | locale を**除いた**キー（`views.foo`） | locale を**含む**キー（`ja.views.foo`） |
-| 作用タイミング | lookup（読み込み）時 | upload（送信）時 |
-| 効果 | ローカル YAML を優先（完全分離） | サーバへのアップロードを抑止するだけ |
-
-`exclude_key_regexp` は PR #110 で非推奨化された（設定すると `ActiveSupport::Deprecation` 警告が出る）。
-移行では使わない。もし既存設定に `exclude_key_regexp` があれば、cleanup スキルで gem ごと撤去される。
+かつて存在した `exclude_key_regexp` オプションは v2 で削除済み。`local_first_key_regexp` を使うこと
+（対象は locale を**除いた**キー `views.foo`、lookup 時に作用しローカル YAML を優先＝完全分離）。
+既存 initializer に `exclude_key_regexp` の設定が残っている場合は削除する。

--- a/spec/copy_tuner_client/cache_spec.rb
+++ b/spec/copy_tuner_client/cache_spec.rb
@@ -24,16 +24,6 @@ describe 'CopyTunerClient::Cache' do
     expect(cache.keys).to match_array(%w[en.test.key en.test.other_key])
   end
 
-  it 'exclude_key_regexpが設定されている場合、該当データを除外すること' do
-    cache = build_cache(exclude_key_regexp: /^en\.test\.other_key$/)
-    cache['en.test.key']       = 'expected'
-    cache['en.test.other_key'] = 'expected'
-
-    cache.download
-
-    expect(cache.queued.keys).to match_array(%w[en.test.key])
-  end
-
   it 'local_first_key_regexpにマッチするキー（locale除く）はアップロードキューに入れないこと' do
     cache = build_cache(local_first_key_regexp: /\Aviews\./)
     cache['ja.views.foo']    = 'local value'
@@ -284,6 +274,7 @@ describe 'CopyTunerClient::Cache' do
   it 'トップレベルからflushできること' do
     cache = build_cache
     CopyTunerClient.configure do |config|
+      config.project_id = 1
       config.cache = cache
     end
     expect(cache).to receive(:flush).at_least(:once)
@@ -410,6 +401,7 @@ describe 'CopyTunerClient::Cache' do
 
     it 'トップレベル定数から呼び出せること' do
       CopyTunerClient.configure do |config|
+        config.project_id = 1
         config.cache = cache
       end
       expect(cache).to receive(:export)

--- a/spec/copy_tuner_client/client_spec.rb
+++ b/spec/copy_tuner_client/client_spec.rb
@@ -207,6 +207,7 @@ describe 'CopyTunerClient' do
     client = build_client
     allow(client).to receive(:download)
     CopyTunerClient.configure do |config|
+      config.project_id = 1
       config.client = client
     end
     expect(client).to receive(:deploy)

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -253,27 +253,24 @@ describe CopyTunerClient::Configuration do
     end
   end
 
-  describe '#exclude_key_regexp= (deprecated)' do
-    let(:config) { CopyTunerClient::Configuration.new }
-    let(:deprecator) { instance_double(ActiveSupport::Deprecation, warn: nil) }
-
-    before { allow(ActiveSupport::Deprecation).to receive(:new).and_return(deprecator) }
-
-    it 'warns when a value is set' do
-      expect(deprecator).to receive(:warn).with(/exclude_key_regexp is deprecated/)
-
-      config.exclude_key_regexp = /\Aja\.views\./
+  describe 'project_id の必須化' do
+    let(:config) do
+      config = CopyTunerClient::Configuration.new
+      config.api_key = 'abc123'
+      config
     end
 
-    it 'stores the assigned value' do
-      config.exclude_key_regexp = /\Aja\.views\./
-      expect(config.exclude_key_regexp).to eq(/\Aja\.views\./)
+    it 'project_id が未設定のとき apply が ArgumentError を出すこと' do
+      expect { config.apply }.to raise_error(ArgumentError, 'project_id is required')
     end
 
-    it 'does not warn when set to nil' do
-      expect(deprecator).not_to receive(:warn)
+    it 'project_id が未設定のとき project_url が ArgumentError を出すこと' do
+      expect { config.project_url }.to raise_error(ArgumentError, 'project_id is required')
+    end
 
-      config.exclude_key_regexp = nil
+    it 'project_id を設定すると project_url がそれを使った URL を返すこと' do
+      config.project_id = 77
+      expect(config.project_url).to include('/projects/77')
     end
   end
 end
@@ -294,6 +291,9 @@ shared_context 'stubbed configuration' do
     allow(CopyTunerClient::Poller).to receive(:new).and_return(poller)
     allow(CopyTunerClient::ProcessGuard).to receive(:new).and_return(process_guard)
     subject.logger = logger
+    # NOTE: apply は project_id 必須になったため、未設定だと raise する。applied 系テストは
+    #       project_id 自体を検証しないので適当な値を補っておく
+    subject.project_id ||= 1
     apply
   end
 end

--- a/spec/copy_tuner_client/copyray_middleware_spec.rb
+++ b/spec/copy_tuner_client/copyray_middleware_spec.rb
@@ -16,6 +16,7 @@ describe CopyTunerClient::CopyrayMiddleware do
 
   before do
     CopyTunerClient.configure do |configuration|
+      configuration.project_id = 1
       configuration.client = FakeClient.new
     end
     # NOTE: CSS/JS 挿入は Rails の ActionController::Base.helpers に依存するため、

--- a/spec/copy_tuner_client/copyray_spec.rb
+++ b/spec/copy_tuner_client/copyray_spec.rb
@@ -9,6 +9,7 @@ describe CopyTunerClient::Copyray do
 
     before do
       CopyTunerClient.configure do |configuration|
+        configuration.project_id = 1
         configuration.client = FakeClient.new
       end
     end


### PR DESCRIPTION
v2 正式リリースに向けて、後方互換のため残していた非推奨機能を削除する。いずれも破壊的変更のため CHANGELOG に明記済み。

## 変更内容

- **`exclude_key_regexp` の完全削除** — `@deprecated` とマークされていたオプションを削除。`Cache#[]=` のアップロード抑止ガード、`Configuration` の `OPTIONS` / `attr_reader` / セッターを削除し、ドキュメント（README・CLAUDE.md・移行スキル）を後継の `local_first_key_regexp` 一本に整理。
- **`project_id` の必須化** — 未設定時に `api_key` へフォールバックして deprecation 警告を出す経路を削除し、`project_id` を必須化（`ArgumentError: project_id is required`）。検証は `apply` で行い、`apply` を経ない `project_url` 直接呼び出しのセーフネットも兼ねて private メソッド `validate_project_id!` に集約。

## テスト

`bundle exec rspec` で全 292 examples グリーン（1 pending は既存の xit）。`exclude_key_regexp` の deprecated テストを削除し、`project_id` 必須化の RED テストを追加。`apply` を通す既存テストには `project_id` を補完した。