### PR TITLE
[review] CopyrayMiddleware で turbo stream レスポンスも書き換え対象にする

### DIFF
--- a/lib/copy_tuner_client/copyray/rewriter.rb
+++ b/lib/copy_tuner_client/copyray/rewriter.rb
@@ -19,7 +19,10 @@ module CopyTunerClient
         # NOTE: 戻り値は [html, skipped]。skipped は data-copyray-key を付与できなかったことを表す
         # （巨大DOMでのスキップ・Nokogiri 例外の双方で true）。ミドルウェアがこれを JS に伝え、
         # オーバーレイ非対応である旨をツールバーで案内する。
-        def rewrite(html)
+        # NOTE: fragment: true は turbo stream など body に差し込む HTML 断片向け。
+        # Nokogiri::HTML だと html/body/DOCTYPE ラッパが付いて断片が壊れるため、
+        # fragment パーサでラッパを付けずに走査・除去する。
+        def rewrite(html, fragment: false)
           # NOTE: ボディが ASCII-8BIT に転落していると UTF-8 の Marker::PREFIX との include? 比較が
           # Encoding::CompatibilityError を投げる（ミドルウェアのボディ連結で非ASCIIバイトを含む
           # ASCII-8BIT チャンクが混じると発生）。実バイト列は本来 UTF-8 なので判定用に UTF-8 とみなす。
@@ -35,7 +38,7 @@ module CopyTunerClient
           # NOTE: 閾値超は Nokogiri を通さず可視トークン除去のみ。skipped=true で編集導線を諦めた旨を伝える。
           return [strip_markers(scannable), true] if scannable.bytesize > MAX_REWRITE_BYTESIZE
 
-          [rewrite_with_nokogiri(scannable), false]
+          [rewrite_with_nokogiri(scannable, fragment: fragment), false]
         rescue StandardError => e
           # NOTE: Copyray は開発支援機能なので、壊れた HTML 等で Nokogiri 処理が落ちても
           # ページを 500 にしない。data-copyray-key 付与（編集導線）は諦め、最低限可視トークンだけ除去する。
@@ -51,8 +54,8 @@ module CopyTunerClient
           scannable.gsub(Marker::SCAN_REGEXP, '')
         end
 
-        def rewrite_with_nokogiri(scannable)
-          doc = Nokogiri::HTML(scannable)
+        def rewrite_with_nokogiri(scannable, fragment: false)
+          doc = fragment ? Nokogiri::HTML.fragment(scannable) : Nokogiri::HTML(scannable)
 
           doc.traverse do |node|
             if node.text?

--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -11,18 +11,22 @@ module CopyTunerClient
     def call(env)
       CopyTunerClient::TranslationLog.clear
       status, headers, response = @app.call(env)
-      if html_headers?(status, headers) && body = response_body(response)
+      if rewritable?(status, headers) && body = response_body(response)
         csp_nonce = env['action_dispatch.content_security_policy_nonce'] || env['secure_headers_content_security_policy_nonce']
         # NOTE: CSS/JS 挿入の前に Rewriter を通す。serialize 後も </body> は必ず出力されるので
         # append_to_html_body の rindex は機能し、CSS/JS タグはトークン非含有なので二重処理も起きない。
         # NOTE: skipped は data-copyray-key を付与できなかったこと（巨大DOM/Nokogiri例外）を表す。
         # JS にこれを伝え、オーバーレイ非対応である旨をツールバーで案内させる。
-        body, skipped = CopyTunerClient::Copyray::Rewriter.rewrite(body)
-        body = append_js(body, csp_nonce, skipped: skipped)
+        # NOTE: turbo stream はページ断片なので fragment パーサで走査する（html/body ラッパを付けない）。
+        turbo_stream = turbo_stream?(headers)
+        body, skipped = CopyTunerClient::Copyray::Rewriter.rewrite(body, fragment: turbo_stream)
+        # NOTE: ブートストラップ JS はフルページ読み込み時に一度だけ挿入すればよい。turbo stream 断片には
+        # 挿入先の </body> も無く、既に初期化済みのページへマージされるだけなので挿入しない。
+        body = append_js(body, csp_nonce, skipped: skipped) unless turbo_stream
         content_length = body.bytesize.to_s
         headers['Content-Length'] = content_length
         # maintains compatibility with other middlewares
-        if defined?(ActionDispatch::Response::RackBody) && ActionDispatch::Response::RackBody === response
+        if defined?(ActionDispatch::Response::RackBody) && response.is_a?(ActionDispatch::Response::RackBody)
           ActionDispatch::Response.new(status, headers, [body]).to_a
         else
           [status, headers, [body]]
@@ -65,14 +69,19 @@ module CopyTunerClient
     end
 
     def file?(headers)
-      headers["Content-Transfer-Encoding"] == 'binary'
+      headers['Content-Transfer-Encoding'] == 'binary'
     end
 
-    def html_headers?(status, headers)
+    def rewritable?(status, headers)
       [200, 422].include?(status) &&
+        headers['Content-Type'] &&
+        (headers['Content-Type'].include?('text/html') || turbo_stream?(headers)) &&
+        !file?(headers)
+    end
+
+    def turbo_stream?(headers)
       headers['Content-Type'] &&
-      headers['Content-Type'].include?('text/html') &&
-      !file?(headers)
+        headers['Content-Type'].include?('text/vnd.turbo-stream.html')
     end
 
     def response_body(response)

--- a/spec/copy_tuner_client/copyray/rewriter_spec.rb
+++ b/spec/copy_tuner_client/copyray/rewriter_spec.rb
@@ -202,6 +202,22 @@ describe CopyTunerClient::Copyray::Rewriter do
       end
     end
 
+    context 'fragment: true（turbo stream などの HTML 断片）' do
+      let(:html) { %(<turbo-stream action="replace" target="x"><template><p>#{marker('a.b')}Hello</p></template></turbo-stream>) }
+      subject(:result) { described_class.rewrite(html, fragment: true).first }
+
+      it 'html/body ラッパを足さず断片のまま返す' do
+        expect(result).not_to include('<html>')
+        expect(result).not_to include('<body>')
+        expect(result).to start_with('<turbo-stream')
+      end
+
+      it 'template 内の要素に data-copyray-key を付与しトークンを除去する' do
+        expect(result).to include('data-copyray-key="a.b"')
+        expect(result).not_to match CopyTunerClient::Copyray::Marker::SCAN_REGEXP
+      end
+    end
+
     context '出力にマーカートークンが一切残らない' do
       let(:html) do
         "<html><head><title>#{marker('t')}T</title></head>" \

--- a/spec/copy_tuner_client/copyray_middleware_spec.rb
+++ b/spec/copy_tuner_client/copyray_middleware_spec.rb
@@ -41,6 +41,40 @@ describe CopyTunerClient::CopyrayMiddleware do
     end
   end
 
+  context 'turbo stream レスポンスのとき' do
+    let(:headers) { { 'Content-Type' => 'text/vnd.turbo-stream.html' } }
+    let(:body) { %(<turbo-stream action="replace" target="x"><template><p>#{marker('a.b')}Hello</p></template></turbo-stream>) }
+
+    before do
+      # NOTE: append_js のトップレベル no-op スタブを外し、turbo stream では JS を挿入しないことを検証する。
+      allow(middleware).to receive(:append_js).and_call_original
+    end
+
+    it 'マーカーを data-copyray-key 属性に書き換え、トークンを除去する' do
+      _status, _headers, response = middleware.call({})
+      result = response.join
+
+      expect(result).to include('data-copyray-key="a.b"')
+      expect(result).not_to match CopyTunerClient::Copyray::Marker::SCAN_REGEXP
+    end
+
+    it 'html/body ラッパを付けず turbo-stream 断片のまま返す' do
+      _status, _headers, response = middleware.call({})
+      result = response.join
+
+      expect(result).to start_with('<turbo-stream')
+      expect(result).not_to include('<body>')
+    end
+
+    it 'ブートストラップ JS を挿入しない（断片なので）' do
+      _status, _headers, response = middleware.call({})
+      result = response.join
+
+      expect(result).not_to include('window.CopyTuner')
+      expect(result).not_to include('copytuner')
+    end
+  end
+
   context 'HTML 以外のレスポンスのとき' do
     let(:headers) { { 'Content-Type' => 'application/json' } }
     let(:body) { "{\"x\":\"#{marker('a.b')}\"}" }


### PR DESCRIPTION
## 概要
`CopyrayMiddleware` が turbo stream レスポンス（`text/vnd.turbo-stream.html`）も処理対象にする。これまで turbo stream は素通りしていたため、マーカートークンが画面に露出していた。fragment パーサで走査してトークン除去と `data-copyray-key` 付与を行う。

## 変更点
- `html_headers?` を `rewritable?` に置き換え、`text/html` に加えて turbo stream の content type も受理する
- turbo stream のときは `Rewriter` を `fragment: true` で呼ぶ
- turbo stream 断片にはブートストラップ JS を挿入しない

## 見てほしいポイント
- **fragment パーサの使い分け**: 通常の `Nokogiri::HTML` は出力を `html/body/DOCTYPE` でラップして turbo stream 断片を壊すため、`Nokogiri::HTML.fragment` を使い分けている（`<template>` 内部までトラバースして属性付与できることは確認済み）。
- **JS 非挿入の判断**: 挿入先の `</body>` が無く、既に初期化済みのページへマージされるだけなので turbo stream 断片には挿入しない。

## テスト
RED/TDD で実装。middleware / rewriter 双方に turbo stream・fragment のケースを追加し、全 297 examples パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)