### PR TITLE
fix: RuboCop 違反の解消と ProcessGuard フォークテストの根本修正

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -182,11 +182,6 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 4
 
-# Offense count: 1
-RSpec/PendingWithoutReason:
-  Exclude:
-    - 'spec/copy_tuner_client/process_guard_spec.rb'
-
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 RSpec/ReceiveMessages:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -71,14 +71,6 @@ Naming/MethodParameterName:
   Exclude:
     - 'lib/copy_tuner_client/queue_with_timeout.rb'
 
-# Offense count: 1
-# Configuration parameters: Mode, AllowedMethods, AllowedPatterns, AllowBangMethods, WaywardPredicates.
-# AllowedMethods: call
-# WaywardPredicates: infinite?, nonzero?
-Naming/PredicateMethod:
-  Exclude:
-    - 'spec/copy_tuner_client/cache_spec.rb'
-
 # Offense count: 26
 # This cop supports unsafe autocorrection (--autocorrect-all).
 RSpec/BeEq:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Categories, ExpectedOrder.
-# ExpectedOrder: module_inclusion, constants, public_class_methods, initializer, public_methods, protected_methods, private_methods
-Layout/ClassStructure:
-  Exclude:
-    - 'spec/support/fake_copy_tuner_app.rb'
-
 # Offense count: 3
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSafeAssignment.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowSafeAssignment.
-Lint/AssignmentInCondition:
-  Exclude:
-    - 'lib/copy_tuner_client/copyray_middleware.rb'
-    - 'spec/support/fake_copy_tuner_app.rb'
-
 # Offense count: 8
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums

--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -11,7 +11,7 @@ module CopyTunerClient
     def call(env)
       CopyTunerClient::TranslationLog.clear
       status, headers, response = @app.call(env)
-      if rewritable?(status, headers) && body = response_body(response)
+      if rewritable?(status, headers) && (body = response_body(response))
         csp_nonce = env['action_dispatch.content_security_policy_nonce'] ||
                     env['secure_headers_content_security_policy_nonce']
         # NOTE: CSS/JS 挿入の前に Rewriter を通す。serialize 後も </body> は必ず出力されるので

--- a/spec/copy_tuner_client/cache_spec.rb
+++ b/spec/copy_tuner_client/cache_spec.rb
@@ -228,7 +228,7 @@ describe 'CopyTunerClient::Cache' do
         sleep(0.1)
 
         if thread.status == false
-          violated('アンロック前に終了してしまった')
+          violated?('アンロック前に終了してしまった')
         else
           mutex.unlock
           sleep(0.1)
@@ -236,12 +236,12 @@ describe 'CopyTunerClient::Cache' do
           if thread.status == false
             true
           else
-            violated('アンロック後もスレッドが終了しない')
+            violated?('アンロック後もスレッドが終了しない')
           end
         end
       end
 
-      def violated(failure)
+      def violated?(failure)
         @failure_message = failure
         false
       end

--- a/spec/copy_tuner_client/process_guard_spec.rb
+++ b/spec/copy_tuner_client/process_guard_spec.rb
@@ -79,8 +79,7 @@ describe CopyTunerClient::ProcessGuard do
     unicorn.spawn
   end
 
-  # FIXME: ruby@2.7以降で失敗するようになっているがテストコードの問題っぽいのでスキップしている
-  xit 'flushes when the process terminates' do
+  it 'flushes when the process terminates', skip: 'ruby@2.7以降で失敗するようになっているがテストコードの問題っぽいのでスキップしている' do
     cache = WritingCache.new
     fork do
       process_guard = build_process_guard(cache:, preserve_exit_hook: true)

--- a/spec/copy_tuner_client/process_guard_spec.rb
+++ b/spec/copy_tuner_client/process_guard_spec.rb
@@ -79,8 +79,9 @@ describe CopyTunerClient::ProcessGuard do
     unicorn.spawn
   end
 
-  it 'flushes when the process terminates', skip: 'ruby@2.7以降で失敗するようになっているがテストコードの問題っぽいのでスキップしている' do
+  it 'flushes when the process terminates' do
     cache = WritingCache.new
+    FileUtils.rm_f(File.join(PROJECT_ROOT, 'tmp', 'written_cache'))
     fork do
       process_guard = build_process_guard(cache:, preserve_exit_hook: true)
       process_guard.start

--- a/spec/support/fake_copy_tuner_app.rb
+++ b/spec/support/fake_copy_tuner_app.rb
@@ -84,6 +84,52 @@ class FakeCopyTunerApp < Sinatra::Base
   class Project
     attr_reader :draft, :published, :api_key
 
+    MUTEX = Mutex.new
+
+    def self.create(api_key)
+      project = Project.new('api_key' => api_key)
+      save project
+      project
+    end
+
+    def self.find(api_key)
+      open_project_data do |data|
+        if project_hash = data[api_key]
+          Project.new project_hash.dup
+        end
+      end
+    end
+
+    def self.delete_all
+      open_project_data(&:clear)
+    end
+
+    def self.save(project)
+      open_project_data do |data|
+        data[project.api_key] = project.to_hash
+      end
+    end
+
+    def self.open_project_data
+      MUTEX.synchronize do
+        project_file = File.expand_path('../../tmp/projects.json', __dir__)
+        FileUtils.mkdir_p File.dirname(project_file)
+
+        data =
+          if File.exist? project_file
+            JSON.parse(File.read(project_file))
+          else
+            {}
+          end
+
+        result = yield(data)
+
+        File.write(project_file, data.to_json)
+
+        result
+      end
+    end
+
     def initialize(attrs)
       @api_key = attrs['api_key']
       @draft = attrs['draft'] || {}
@@ -120,51 +166,6 @@ class FakeCopyTunerApp < Sinatra::Base
 
     def etag
       @etag.to_s
-    end
-
-    def self.create(api_key)
-      project = Project.new('api_key' => api_key)
-      save project
-      project
-    end
-
-    def self.find(api_key)
-      open_project_data do |data|
-        if project_hash = data[api_key]
-          Project.new project_hash.dup
-        end
-      end
-    end
-
-    def self.delete_all
-      open_project_data(&:clear)
-    end
-
-    def self.save(project)
-      open_project_data do |data|
-        data[project.api_key] = project.to_hash
-      end
-    end
-
-    MUTEX = Mutex.new
-    def self.open_project_data
-      MUTEX.synchronize do
-        project_file = File.expand_path('../../tmp/projects.json', __dir__)
-        FileUtils.mkdir_p File.dirname(project_file)
-
-        data =
-          if File.exist? project_file
-            JSON.parse(File.read(project_file))
-          else
-            {}
-          end
-
-        result = yield(data)
-
-        File.write(project_file, data.to_json)
-
-        result
-      end
     end
   end
 end

--- a/spec/support/fake_copy_tuner_app.rb
+++ b/spec/support/fake_copy_tuner_app.rb
@@ -36,7 +36,7 @@ class FakeCopyTunerApp < Sinatra::Base
   def with_project(api_key)
     if api_key == 'raise_error'
       halt 500, { error: 'Blah ha' }.to_json
-    elsif project = Project.find(api_key)
+    elsif (project = Project.find(api_key))
       yield project
     else
       halt 404, { error: 'No such project' }.to_json
@@ -94,7 +94,7 @@ class FakeCopyTunerApp < Sinatra::Base
 
     def self.find(api_key)
       open_project_data do |data|
-        if project_hash = data[api_key]
+        if (project_hash = data[api_key])
           Project.new project_hash.dup
         end
       end

--- a/spec/support/writing_cache.rb
+++ b/spec/support/writing_cache.rb
@@ -1,10 +1,12 @@
 class WritingCache
+  FLUSHED = 'flushed'.freeze
+
   def flush
-    File.write(path, object_id.to_s)
+    File.write(path, FLUSHED)
   end
 
   def written?
-    File.read(path) == object_id.to_s
+    File.exist?(path) && File.read(path) == FLUSHED
   end
 
   private


### PR DESCRIPTION
## Summary
- RuboCop `RSpec/PendingWithoutReason` / `Lint/AssignmentInCondition` / `Naming/PredicateMethod` / `Layout/ClassStructure` の違反を解消
- `ProcessGuard` の fork テストで `WritingCache#written?` が `object_id` に依存していたためRuby 2.7以降で不安定になっていた問題を根本修正し、スキップを解除
  - fork前後のオブジェクト同一性確認を `object_id` 比較から固定文字列書き込み・比較方式に変更
  - テスト実行前に残骸ファイルを削除し、多重実行時の誤 green を防止

## Test plan
- [x] `bundle exec rspec` で全テストがパスすることを確認
- [x] `spec/copy_tuner_client/process_guard_spec.rb` を複数回連続実行し、フレークがないことを確認
- [x] `bundle exec rubocop` で違反が解消されていることを確認