### PR TITLE
fix: RuboCop の残存違反を解消する

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,12 +21,6 @@ Lint/EmptyBlock:
   Exclude:
     - 'spec/copy_tuner_client/client_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
-Metrics/AbcSize:
-  Exclude:
-    - 'lib/copy_tuner_client/helper_extension.rb'
-
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,14 +63,6 @@ Naming/MethodParameterName:
   Exclude:
     - 'lib/copy_tuner_client/queue_with_timeout.rb'
 
-# Offense count: 26
-# This cop supports unsafe autocorrection (--autocorrect-all).
-RSpec/BeEq:
-  Exclude:
-    - 'spec/copy_tuner_client/cache_spec.rb'
-    - 'spec/copy_tuner_client/client_spec.rb'
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-
 # Offense count: 52
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -84,20 +84,6 @@ RSpec/DescribeMethod:
     - 'spec/copy_tuner_client/configuration_spec.rb'
     - 'spec/copy_tuner_client/request_sync_spec.rb'
 
-# Offense count: 32
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.
-# SupportedStyles: described_class, explicit
-RSpec/DescribedClass:
-  Exclude:
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-    - 'spec/copy_tuner_client/copyray_spec.rb'
-    - 'spec/copy_tuner_client/dotted_hash_spec.rb'
-    - 'spec/copy_tuner_client/helper_extension_spec.rb'
-    - 'spec/copy_tuner_client/prefixed_logger_spec.rb'
-    - 'spec/copy_tuner_client/request_sync_spec.rb'
-    - 'spec/copy_tuner_client_spec.rb'
-
 # Offense count: 45
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -276,9 +276,3 @@ Style/SpecialGlobalVars:
     - 'lib/copy_tuner_client/process_guard.rb'
     - 'spec/copy_tuner_client/process_guard_spec.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Mode.
-Style/StringConcatenation:
-  Exclude:
-    - 'lib/copy_tuner_client/copyray_middleware.rb'

--- a/lib/copy_tuner_client/copyray_middleware.rb
+++ b/lib/copy_tuner_client/copyray_middleware.rb
@@ -67,7 +67,7 @@ module CopyTunerClient
       return html unless html.include?('</body>')
 
       position = html.rindex('</body>')
-      html.insert(position, content + "\n")
+      html.insert(position, "#{content}\n")
     end
 
     def file?(headers)

--- a/lib/copy_tuner_client/helper_extension.rb
+++ b/lib/copy_tuner_client/helper_extension.rb
@@ -1,63 +1,70 @@
 module CopyTunerClient
   module HelperExtension
+    # NOTE: class_eval ブロック内で def すると、ブロック内メソッドの複雑さが
+    # hook_translation_helper 自体の Metrics/AbcSize としてカウントされてしまうため、
+    # メソッド本体は独立したモジュールに切り出して include する。
+    module CopyrayCommentInjection
+      def translate_with_copyray_comment(key, **options)
+        source = translate_without_copyray_comment(key, **options)
+
+        return source if controller && CopyTunerClient::Rails.controller_of_rails_engine?(controller)
+
+        # TODO: test
+        # NOTE: default引数が設定されている場合は、copytunerキャッシュの値をI18n.t呼び出しにより上書きしている
+        # SEE: https://github.com/rails/rails/blob/6c43ebc220428ce9fc9569c2e5df90a38a4fc4e4/actionview/lib/action_view/helpers/translation_helper.rb#L82
+        if options.key?(:default)
+          I18n.t(key.to_s.first == '.' ? scope_key_by_partial(key) : key, **options)
+        end
+
+        # NOTE: マーカーは HTML コメントとしてブラウザに無視されつつ Copyray オーバーレイのキー特定に
+        # 使われる。HTML 以外の経路（メール本文・render :json・CSV/PDF など）ではコメントが文字列として
+        # 出力に混入してしまうため、それらの経路には注入しない。default 引数による初期値登録は維持する
+        # 必要があるため、このガードは初期値登録（上の I18n.t 呼び出し）より後に置く。
+        return source unless copyray_injectable?
+
+        if CopyTunerClient.configuration.disable_copyray_comment_injection
+          source
+        else
+          CopyTunerClient::Copyray.augment_template(source, copyray_scope_key(key, options))
+        end
+      end
+
+      def copyray_scope_key(key, options)
+        return scope_key_by_partial(key) if key.to_s.first == '.'
+
+        separator = options[:separator] || I18n.default_separator
+        # NOTE: locale prefix無しのkeyが必要のためこうしている
+        I18n.normalize_keys(nil, key, options[:scope], separator).compact.join(separator)
+      end
+      private :copyray_scope_key
+
+      # NOTE: HTML 以外の経路（メール本文・render :json・CSV/PDF など）ではマーカーが文字列として
+      # 出力に混入するため注入しない。判定には controller.request.format を使い、@current_template.format /
+      # lookup_context.formats のような ActionView の内部実装には依存させない（Rails バージョン間で壊れうるため）。
+      def copyray_injectable?
+        current_controller = controller
+        return false if current_controller.nil?
+
+        # NOTE: mailer は request を持たず request.format で判定できない。かつメール本文への
+        # マーカー混入は実害が大きいため、controller の型で明示除外する。
+        return false if defined?(ActionMailer::Base) && current_controller.is_a?(ActionMailer::Base)
+
+        # NOTE: request が無い／format が html でない経路には注入しない。&. と || false で
+        # request 不在時も安全に false を返す。
+        current_controller.request&.format&.html? || false
+      end
+      private :copyray_injectable?
+    end
+    private_constant :CopyrayCommentInjection
+
     def self.hook_translation_helper(mod, middleware_enabled:)
+      return unless middleware_enabled
+
+      mod.include(CopyrayCommentInjection)
       mod.class_eval do
-        def translate_with_copyray_comment(key, **options)
-          source = translate_without_copyray_comment(key, **options)
-
-          return source if controller && CopyTunerClient::Rails.controller_of_rails_engine?(controller)
-
-          # TODO: test
-          # NOTE: default引数が設定されている場合は、copytunerキャッシュの値をI18n.t呼び出しにより上書きしている
-          # SEE: https://github.com/rails/rails/blob/6c43ebc220428ce9fc9569c2e5df90a38a4fc4e4/actionview/lib/action_view/helpers/translation_helper.rb#L82
-          if options.key?(:default)
-            I18n.t(key.to_s.first == '.' ? scope_key_by_partial(key) : key, **options)
-          end
-
-          # NOTE: マーカーは HTML コメントとしてブラウザに無視されつつ Copyray オーバーレイのキー特定に
-          # 使われる。HTML 以外の経路（メール本文・render :json・CSV/PDF など）ではコメントが文字列として
-          # 出力に混入してしまうため、それらの経路には注入しない。default 引数による初期値登録は維持する
-          # 必要があるため、このガードは初期値登録（上の I18n.t 呼び出し）より後に置く。
-          return source unless copyray_injectable?
-
-          if CopyTunerClient.configuration.disable_copyray_comment_injection
-            source
-          else
-            separator = options[:separator] || I18n.default_separator
-            scope = options[:scope]
-            scope_key =
-              if key.to_s.first == '.'
-                scope_key_by_partial(key)
-              else
-                # NOTE: locale prefix無しのkeyが必要のためこうしている
-                I18n.normalize_keys(nil, key, scope, separator).compact.join(separator)
-              end
-            CopyTunerClient::Copyray.augment_template(source, scope_key)
-          end
-        end
-
-        # NOTE: HTML 以外の経路（メール本文・render :json・CSV/PDF など）ではマーカーが文字列として
-        # 出力に混入するため注入しない。判定には controller.request.format を使い、@current_template.format /
-        # lookup_context.formats のような ActionView の内部実装には依存させない（Rails バージョン間で壊れうるため）。
-        def copyray_injectable?
-          current_controller = controller
-          return false if current_controller.nil?
-
-          # NOTE: mailer は request を持たず request.format で判定できない。かつメール本文への
-          # マーカー混入は実害が大きいため、controller の型で明示除外する。
-          return false if defined?(ActionMailer::Base) && current_controller.is_a?(ActionMailer::Base)
-
-          # NOTE: request が無い／format が html でない経路には注入しない。&. と || false で
-          # request 不在時も安全に false を返す。
-          current_controller.request&.format&.html? || false
-        end
-        private :copyray_injectable?
-
-        if middleware_enabled
-          alias_method :translate_without_copyray_comment, :translate
-          alias_method :translate, :translate_with_copyray_comment
-          alias_method :t, :translate
-        end
+        alias_method :translate_without_copyray_comment, :translate
+        alias_method :translate, :translate_with_copyray_comment
+        alias_method :t, :translate
       end
     end
   end

--- a/spec/copy_tuner_client/cache_spec.rb
+++ b/spec/copy_tuner_client/cache_spec.rb
@@ -137,7 +137,7 @@ describe 'CopyTunerClient::Cache' do
     cache.download
 
     expect(cache['en.test.key']).to eq('test value')
-    expect(cache['en.test.empty']).to eq(nil)
+    expect(cache['en.test.empty']).to be_nil
     expect(cache.blank_keys).to contain_exactly('en.test.empty')
 
     cache['en.test.empty'] = ''
@@ -209,7 +209,7 @@ describe 'CopyTunerClient::Cache' do
 
     sleep(1)
 
-    expect(finished).to eq(true)
+    expect(finished).to be(true)
     expect(logger).not_to have_entry(:info, 'Waiting for first download')
   end
 
@@ -410,7 +410,7 @@ describe 'CopyTunerClient::Cache' do
     end
 
     it 'blurbキーがない場合はyamlを返さないこと' do
-      expect(subject).to eq nil
+      expect(subject).to be_nil
     end
 
     context '1階層のblurbキーがある場合' do

--- a/spec/copy_tuner_client/client_spec.rb
+++ b/spec/copy_tuner_client/client_spec.rb
@@ -52,7 +52,7 @@ describe 'CopyTunerClient' do
       project = add_project
       client = build_client(api_key: project.api_key, secure: true)
       client.download { |ignore| }
-      expect(http.use_ssl?).to eq(true)
+      expect(http.use_ssl?).to be(true)
       expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
     end
 
@@ -60,7 +60,7 @@ describe 'CopyTunerClient' do
       project = add_project
       client = build_client(api_key: project.api_key, secure: false)
       client.download { |ignore| }
-      expect(http.use_ssl?).to eq(false)
+      expect(http.use_ssl?).to be(false)
     end
 
     it 'HTTPエラーをConnectionErrorでラップすること' do

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -195,26 +195,26 @@ describe CopyTunerClient::Configuration do
     let(:config) { CopyTunerClient::Configuration.new }
 
     it 'returns false when local_first_key_regexp is nil (default)' do
-      expect(config.local_first_key?('views.foo.bar')).to eq false
+      expect(config.local_first_key?('views.foo.bar')).to be false
     end
 
     context 'when local_first_key_regexp is set' do
       before { config.local_first_key_regexp = /\Aviews\./ }
 
       it 'returns true for a matching key' do
-        expect(config.local_first_key?('views.foo.bar')).to eq true
+        expect(config.local_first_key?('views.foo.bar')).to be true
       end
 
       it 'returns false for a non-matching key' do
-        expect(config.local_first_key?('models.foo.bar')).to eq false
+        expect(config.local_first_key?('models.foo.bar')).to be false
       end
 
       it 'returns false for a nil key' do
-        expect(config.local_first_key?(nil)).to eq false
+        expect(config.local_first_key?(nil)).to be false
       end
 
       it 'coerces a Symbol key before matching' do
-        expect(config.local_first_key?(:'views.foo')).to eq true
+        expect(config.local_first_key?(:'views.foo')).to be true
       end
     end
 
@@ -222,33 +222,33 @@ describe CopyTunerClient::Configuration do
     # ユーザー設定の有無によらず常にローカル優先（組み込み判定）になる
     context 'with built-in Rails number format keys' do
       it 'returns true for built-in number format keys even when local_first_key_regexp is nil' do
-        expect(config.local_first_key?('number.format')).to eq true
-        expect(config.local_first_key?('number.currency.format')).to eq true
-        expect(config.local_first_key?('number.currency.format.precision')).to eq true
-        expect(config.local_first_key?('number.percentage.format')).to eq true
-        expect(config.local_first_key?('number.human.format.significant')).to eq true
+        expect(config.local_first_key?('number.format')).to be true
+        expect(config.local_first_key?('number.currency.format')).to be true
+        expect(config.local_first_key?('number.currency.format.precision')).to be true
+        expect(config.local_first_key?('number.percentage.format')).to be true
+        expect(config.local_first_key?('number.human.format.significant')).to be true
       end
 
       it 'returns false for app-defined number keys (not Rails format subtrees)' do
-        expect(config.local_first_key?('number.gift_amount')).to eq false
-        expect(config.local_first_key?('number.my_currency.unit')).to eq false
+        expect(config.local_first_key?('number.gift_amount')).to be false
+        expect(config.local_first_key?('number.my_currency.unit')).to be false
       end
 
       it 'returns false for string-only number subtrees and non-number keys' do
-        expect(config.local_first_key?('number.human.storage_units.units.byte.one')).to eq false
-        expect(config.local_first_key?('date.formats.default')).to eq false
-        expect(config.local_first_key?('time.formats.short')).to eq false
-        expect(config.local_first_key?('datetime.distance_in_words.x')).to eq false
-        expect(config.local_first_key?('views.foo')).to eq false
-        expect(config.local_first_key?('numbers.foo')).to eq false
+        expect(config.local_first_key?('number.human.storage_units.units.byte.one')).to be false
+        expect(config.local_first_key?('date.formats.default')).to be false
+        expect(config.local_first_key?('time.formats.short')).to be false
+        expect(config.local_first_key?('datetime.distance_in_words.x')).to be false
+        expect(config.local_first_key?('views.foo')).to be false
+        expect(config.local_first_key?('numbers.foo')).to be false
       end
 
       it 'keeps protecting built-in keys without breaking a user-set regexp' do
         config.local_first_key_regexp = /\Aviews\./
 
-        expect(config.local_first_key?('number.currency.format')).to eq true
-        expect(config.local_first_key?('views.foo')).to eq true
-        expect(config.local_first_key?('models.foo')).to eq false
+        expect(config.local_first_key?('number.currency.format')).to be true
+        expect(config.local_first_key?('views.foo')).to be true
+        expect(config.local_first_key?('models.foo')).to be false
       end
     end
   end

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -46,21 +46,21 @@ describe CopyTunerClient::Configuration do
   it { is_expected.to have_config_option(:local_first_key_regexp).overridable.default(nil) }
 
   it 'provides default values for secure connections' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     config.secure = true
     expect(config.port).to eq(443)
     expect(config.protocol).to eq('https')
   end
 
   it 'provides default values for insecure connections' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     config.secure = false
     expect(config.port).to eq(80)
     expect(config.protocol).to eq('http')
   end
 
   it 'does not cache inferred ports' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     config.secure = false
     config.port
     config.secure = true
@@ -68,7 +68,7 @@ describe CopyTunerClient::Configuration do
   end
 
   it 'acts like a hash' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     hash = config.to_hash
 
     %i[
@@ -84,30 +84,30 @@ describe CopyTunerClient::Configuration do
   end
 
   it 'is mergable' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     hash = config.to_hash
     expect(config.merge(key: 'value')).to eq(hash.merge(key: 'value'))
   end
 
   it 'uses development and staging as development environments by default' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     expect(config.development_environments).to match_array(%w[development staging])
   end
 
   it 'uses test and cucumber as test environments by default' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     expect(config.test_environments).to match_array(%w[test cucumber])
   end
 
   it 'is test in a test environment' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     config.test_environments = %w[test]
     config.environment_name = 'test'
     expect(config).to be_test
   end
 
   it 'is public in a public environment' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     config.development_environments = %w[development]
     config.environment_name = 'production'
     expect(config).to be_public
@@ -115,7 +115,7 @@ describe CopyTunerClient::Configuration do
   end
 
   it 'is development in a development environment' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     config.development_environments = %w[staging]
     config.environment_name = 'staging'
     expect(config).to be_development
@@ -123,7 +123,7 @@ describe CopyTunerClient::Configuration do
   end
 
   it 'is public without an environment name' do
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     expect(config).to be_public
   end
 
@@ -134,7 +134,7 @@ describe CopyTunerClient::Configuration do
       yielded_configuration = config
     end
 
-    expect(yielded_configuration).to be_a(CopyTunerClient::Configuration)
+    expect(yielded_configuration).to be_a(described_class)
     expect(CopyTunerClient.configuration).to eq(yielded_configuration)
   end
 
@@ -158,13 +158,13 @@ describe CopyTunerClient::Configuration do
   end
 
   it 'starts out unapplied' do
-    expect(CopyTunerClient::Configuration.new).not_to be_applied
+    expect(described_class.new).not_to be_applied
   end
 
   it 'logs to $stdout by default' do
     logger = FakeLogger.new
     expect(Logger).to receive(:new).with($stdout).and_return(logger)
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
     expect(config.logger.original_logger).to eq(logger)
   end
 
@@ -182,7 +182,7 @@ describe CopyTunerClient::Configuration do
 
   it 'prefixes log entries' do
     logger = FakeLogger.new
-    config = CopyTunerClient::Configuration.new
+    config = described_class.new
 
     config.logger = logger
 
@@ -192,7 +192,7 @@ describe CopyTunerClient::Configuration do
   end
 
   describe '#local_first_key?' do
-    let(:config) { CopyTunerClient::Configuration.new }
+    let(:config) { described_class.new }
 
     it 'returns false when local_first_key_regexp is nil (default)' do
       expect(config.local_first_key?('views.foo.bar')).to be false
@@ -255,7 +255,7 @@ describe CopyTunerClient::Configuration do
 
   describe 'project_id の必須化' do
     let(:config) do
-      config = CopyTunerClient::Configuration.new
+      config = described_class.new
       config.api_key = 'abc123'
       config
     end

--- a/spec/copy_tuner_client/copyray_spec.rb
+++ b/spec/copy_tuner_client/copyray_spec.rb
@@ -3,7 +3,7 @@ require 'copy_tuner_client/copyray'
 
 describe CopyTunerClient::Copyray do
   describe '.augment_template' do
-    subject { CopyTunerClient::Copyray.augment_template(source, key) }
+    subject { described_class.augment_template(source, key) }
 
     let(:key) { 'en.test.key' }
 
@@ -41,11 +41,11 @@ describe CopyTunerClient::Copyray do
       before { CopyTunerClient.configuration.local_first_key_regexp = /\Aviews\./ }
 
       it 'does not inject the marker into a plain source' do
-        expect(CopyTunerClient::Copyray.augment_template('Hello', key)).to eq 'Hello'
+        expect(described_class.augment_template('Hello', key)).to eq 'Hello'
       end
 
       it 'does not inject the marker into an html_safe source' do
-        expect(CopyTunerClient::Copyray.augment_template('Hello'.html_safe, key)).to eq 'Hello'
+        expect(described_class.augment_template('Hello'.html_safe, key)).to eq 'Hello'
       end
     end
   end

--- a/spec/copy_tuner_client/dotted_hash_spec.rb
+++ b/spec/copy_tuner_client/dotted_hash_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CopyTunerClient::DottedHash do
   describe '.to_h' do
-    subject { CopyTunerClient::DottedHash.to_h(dotted_hash) }
+    subject { described_class.to_h(dotted_hash) }
 
     context '空のキーの場合' do
       let(:dotted_hash) { {} }
@@ -82,7 +82,7 @@ describe CopyTunerClient::DottedHash do
   end
 
   describe '.conflict_keys' do
-    subject { CopyTunerClient::DottedHash.conflict_keys(dotted_hash) }
+    subject { described_class.conflict_keys(dotted_hash) }
 
     context '有効なキーの場合' do
       let(:dotted_hash) do

--- a/spec/copy_tuner_client/helper_extension_spec.rb
+++ b/spec/copy_tuner_client/helper_extension_spec.rb
@@ -47,7 +47,7 @@ describe CopyTunerClient::HelperExtension do
     include KeywordArgumentsHelper
   end
 
-  CopyTunerClient::HelperExtension.hook_translation_helper(KeywordArgumentsHelper, middleware_enabled: true)
+  described_class.hook_translation_helper(KeywordArgumentsHelper, middleware_enabled: true)
 
   let(:view) { KeywordArgumentsView.new }
 

--- a/spec/copy_tuner_client/prefixed_logger_spec.rb
+++ b/spec/copy_tuner_client/prefixed_logger_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CopyTunerClient::PrefixedLogger do
-  subject { CopyTunerClient::PrefixedLogger.new(prefix, output_logger) }
+  subject { described_class.new(prefix, output_logger) }
 
   let(:output_logger) { FakeLogger.new }
   let(:prefix) { '** NOTICE:' }

--- a/spec/copy_tuner_client/request_sync_spec.rb
+++ b/spec/copy_tuner_client/request_sync_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CopyTunerClient::RequestSync do
-  subject { CopyTunerClient::RequestSync.new(app, poller:, cache:, interval: 0) }
+  subject { described_class.new(app, poller:, cache:, interval: 0) }
 
   let(:poller) { {} }
   let(:cache) { {} }
@@ -22,7 +22,7 @@ describe CopyTunerClient::RequestSync do
 end
 
 describe CopyTunerClient::RequestSync, 'serving assets' do
-  subject { CopyTunerClient::RequestSync.new(app, poller:, cache:, interval: 0) }
+  subject { described_class.new(app, poller:, cache:, interval: 0) }
 
   let(:env) do
     { 'PATH_INFO' => '/assets/choper.png' }
@@ -46,7 +46,7 @@ describe CopyTunerClient::RequestSync, 'serving assets' do
 end
 
 describe CopyTunerClient::RequestSync do
-  subject { CopyTunerClient::RequestSync.new(app, poller:, cache:, interval: 10) }
+  subject { described_class.new(app, poller:, cache:, interval: 10) }
 
   let(:poller) { {} }
   let(:cache) { {} }

--- a/spec/copy_tuner_client_spec.rb
+++ b/spec/copy_tuner_client_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe CopyTunerClient do
   before do
-    allow(CopyTunerClient.configuration).to receive_messages(cache: 'cache', client: 'client')
+    allow(described_class.configuration).to receive_messages(cache: 'cache', client: 'client')
   end
 
   it 'delegates cache to the configuration object' do
-    expect(CopyTunerClient.configuration).to receive(:cache).once
-    expect(CopyTunerClient.cache).to eq('cache')
+    expect(described_class.configuration).to receive(:cache).once
+    expect(described_class.cache).to eq('cache')
   end
 
   it 'delegates client to the configuration object' do
-    expect(CopyTunerClient.configuration).to receive(:client).once
-    expect(CopyTunerClient.client).to eq('client')
+    expect(described_class.configuration).to receive(:client).once
+    expect(described_class.client).to eq('client')
   end
 end


### PR DESCRIPTION
## Summary
- `RSpec/BeEq`: `eq(true)` / `eq(nil)` 等を `be(true)` / `be_nil` に置き換え
- `Style/StringConcatenation`: `+` による文字列結合を文字列補間に変更
- `RSpec/DescribedClass`: spec内のクラス名直書きを `described_class` に置き換え
- `Metrics/AbcSize`: `HelperExtension.hook_translation_helper` の `class_eval` 内 def を `CopyrayCommentInjection` モジュールへ切り出して `include` する構造に変更（振る舞いは維持）

これに伴い `.rubocop_todo.yml` から該当する Exclude エントリを削除。