### PR TITLE
fix: RuboCop 各種違反を解消する

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -92,11 +92,6 @@ RSpec/LeakyConstantDeclaration:
     - 'spec/copy_tuner_client/i18n_backend_spec.rb'
     - 'spec/copy_tuner_client/poller_spec.rb'
 
-# Offense count: 1
-RSpec/MessageChain:
-  Exclude:
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-
 # Offense count: 33
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: have_received, receive

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,12 +143,6 @@ RSpec/NestedGroups:
   Max: 4
 
 # Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-RSpec/ReceiveMessages:
-  Exclude:
-    - 'spec/copy_tuner_client/i18n_backend_spec.rb'
-
-# Offense count: 2
 RSpec/RemoveConst:
   Exclude:
     - 'spec/copy_tuner_client/configuration_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -198,15 +198,6 @@ Style/Documentation:
     - 'lib/copy_tuner_client/simple_form_extention.rb'
     - 'lib/copy_tuner_client/translation_log.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle, AllowedMethods, AllowedPatterns.
-# SupportedStyles: predicate, comparison
-Style/NumericPredicate:
-  Exclude:
-    - 'spec/**/*'
-    - 'lib/copy_tuner_client/queue_with_timeout.rb'
-
 # Offense count: 3
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: respond_to_missing?

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,12 +143,6 @@ RSpec/NestedGroups:
   Max: 4
 
 # Offense count: 2
-RSpec/RemoveConst:
-  Exclude:
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-    - 'spec/support/defines_constants.rb'
-
-# Offense count: 2
 RSpec/RepeatedExampleGroupDescription:
   Exclude:
     - 'spec/copy_tuner_client/request_sync_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,13 +50,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 18
 
-# Offense count: 2
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-# AllowedNames: as, at, by, cc, db, id, if, in, io, ip, of, on, os, pp, to
-Naming/MethodParameterName:
-  Exclude:
-    - 'lib/copy_tuner_client/queue_with_timeout.rb'
-
 # Offense count: 52
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without

--- a/lib/copy_tuner_client/queue_with_timeout.rb
+++ b/lib/copy_tuner_client/queue_with_timeout.rb
@@ -7,17 +7,17 @@ module CopyTunerClient
       @received = ConditionVariable.new
     end
 
-    def <<(x)
+    def <<(item)
       @mutex.synchronize do
-        @queue << x
+        @queue << item
         @received.signal
       end
     end
 
-    def uniq_push(x)
+    def uniq_push(item)
       @mutex.synchronize do
-        unless @queue.member?(x)
-          @queue << x
+        unless @queue.member?(item)
+          @queue << item
           @received.signal
         end
       end

--- a/lib/copy_tuner_client/queue_with_timeout.rb
+++ b/lib/copy_tuner_client/queue_with_timeout.rb
@@ -35,7 +35,7 @@ module CopyTunerClient
         elsif @queue.empty? && timeout != 0
           # wait for element or timeout
           timeout_time = timeout + Time.now.to_f
-          while @queue.empty? && (remaining_time = timeout_time - Time.now.to_f) > 0
+          while @queue.empty? && (remaining_time = timeout_time - Time.now.to_f).positive?
             @received.wait(@mutex, remaining_time)
           end
         end

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -421,19 +421,13 @@ describe CopyTunerClient::Configuration, 'applied with locale filter' do
 end
 
 describe CopyTunerClient::Configuration, 'applied with Rails i18n config' do
-  let!(:rails_defined) { Object.const_defined?(:Rails) }
-
   def self.with_config(i18n_options)
     before do
-      Object.const_set :Rails, Module.new unless rails_defined
+      stub_const('Rails', Module.new)
       i18n = double('i18n', i18n_options)
       config = double('config', i18n:)
       application = double('application', config:)
       allow(Rails).to receive(:application).and_return(application)
-    end
-
-    after do
-      Object.send(:remove_const, :Rails) unless rails_defined
     end
   end
 

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -427,7 +427,9 @@ describe CopyTunerClient::Configuration, 'applied with Rails i18n config' do
     before do
       Object.const_set :Rails, Module.new unless rails_defined
       i18n = double('i18n', i18n_options)
-      allow(Rails).to receive_message_chain(:application, :config, :i18n) { i18n }
+      config = double('config', i18n:)
+      application = double('application', config:)
+      allow(Rails).to receive(:application).and_return(application)
     end
 
     after do

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -400,9 +400,9 @@ describe 'CopyTunerClient::I18nBackend' do
 
       it 'ignored_keysの機能がツリーlookupでも維持されること' do
         # ignored_keys 設定
-        allow(CopyTunerClient.configuration).to receive(:ignored_keys).and_return(['views.secret'])
         handler = double('ignored_key_handler')
-        allow(CopyTunerClient.configuration).to receive(:ignored_key_handler).and_return(handler)
+        allow(CopyTunerClient.configuration).to receive_messages(ignored_keys: ['views.secret'],
+                                                                 ignored_key_handler: handler)
 
         cache['ja.views.public'] = 'public'
         cache['ja.views.secret'] = 'secret'

--- a/spec/support/defines_constants.rb
+++ b/spec/support/defines_constants.rb
@@ -1,12 +1,4 @@
 module DefinesConstants
-  def self.included(example_group)
-    super
-    example_group.class_eval do
-      before { @defined_constants = [] }
-      after { undefine_constants }
-    end
-  end
-
   def define_class(class_name, base = Object, &)
     class_name = class_name.to_s.camelize
     klass = Class.new(base)
@@ -16,29 +8,6 @@ module DefinesConstants
   end
 
   def define_constant(path, value)
-    parse_constant(path) do |parent, name|
-      parent.const_set(name, value)
-    end
-
-    @defined_constants << path
-    value
-  end
-
-  def parse_constant(path)
-    parent_names = path.split('::')
-    name = parent_names.pop
-    parent =
-      parent_names.inject(Object) do |ref, child_name|
-        ref.const_get(child_name)
-      end
-    yield(parent, name)
-  end
-
-  def undefine_constants
-    @defined_constants.reverse.each do |path|
-      parse_constant(path) do |parent, name|
-        parent.send(:remove_const, name)
-      end
-    end
+    stub_const(path, value)
   end
 end


### PR DESCRIPTION
## Summary
- `Naming/MethodParameterName`: `queue_with_timeout.rb` の引数名 `x` を `item` にリネーム
- `Style/NumericPredicate`: `> 0` を `.positive?` に置き換え
- `RSpec/MessageChain`: メッセージチェーンのスタブをネストした `receive` に分解
- `RSpec/ReceiveMessages`: 複数の `receive` スタブを `receive_messages` にまとめる
- `RSpec/RemoveConst`: 独自の定数定義/削除機構を RSpec 標準の `stub_const` に置き換え

## Test plan
- [x] `bundle exec rspec`
- [x] `bundle exec rubocop`