### PR TITLE
fix: RuboCop Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration の違反を解消する

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 8
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: enums
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - 'spec/copy_tuner_client/helper_extension_spec.rb'
-    - 'spec/copy_tuner_client/i18n_backend_spec.rb'
-    - 'spec/copy_tuner_client/poller_spec.rb'
-
 # Offense count: 9
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:
@@ -29,13 +20,6 @@ RSpec/InstanceVariable:
     - 'spec/copy_tuner_client/i18n_backend_spec.rb'
     - 'spec/copy_tuner_client/poller_spec.rb'
     - 'spec/copy_tuner_client/process_guard_spec.rb'
-
-# Offense count: 9
-RSpec/LeakyConstantDeclaration:
-  Exclude:
-    - 'spec/copy_tuner_client/helper_extension_spec.rb'
-    - 'spec/copy_tuner_client/i18n_backend_spec.rb'
-    - 'spec/copy_tuner_client/poller_spec.rb'
 
 # Offense count: 33
 # Configuration parameters: EnforcedStyle.

--- a/spec/copy_tuner_client/helper_extension_spec.rb
+++ b/spec/copy_tuner_client/helper_extension_spec.rb
@@ -3,58 +3,59 @@ require 'copy_tuner_client/helper_extension'
 require 'copy_tuner_client/copyray'
 
 describe CopyTunerClient::HelperExtension do
-  # NOTE: helper_extension が参照する CopyTunerClient::Rails は engine への依存があり
-  # 単体 spec では require できないため、メソッドをスタブできる最小の入れ物だけ用意する。
-  module CopyTunerClient
-    module Rails
-      def self.controller_of_rails_engine?(_controller)
-        false
-      end
-    end
-  end
+  include DefinesConstants
 
   # NOTE: request.format で描画フォーマットを判定するため、format を差し替えられる
   # 最小のフェイク request / controller を用意する。mailer 判定は controller の型で行う。
-  Format =
-    Struct.new(:type) do
-      def html?
-        type == :html
+  def format_class
+    @format_class ||=
+      Struct.new(:type) do
+        def html?
+          type == :html
+        end
       end
-    end
-  Request = Struct.new(:format)
-  Controller = Struct.new(:request)
-
-  module KeywordArgumentsHelper
-    attr_writer :controller
-
-    # NOTE: ActionView の TranslationHelper を模し、.html/_html キーのみ html_safe な訳文を返す。
-    # マーカーは平文・html_safe どちらにも注入されるが、html_safe フラグの引き継ぎを検証できるよう両方返し分ける。
-    def translate(key, **options)
-      source = "Hello, #{options[:name]}"
-      key.to_s.end_with?('.html', '_html') ? source.html_safe : source
-    end
-
-    def controller
-      return @controller if defined?(@controller)
-
-      # NOTE: 実 HTML 描画では controller が存在し request.format が html になるため、
-      # デフォルトはそれを再現した controller。
-      @controller = Controller.new(Request.new(Format.new(:html)))
-    end
   end
 
-  class KeywordArgumentsView
-    include KeywordArgumentsHelper
+  def request_class
+    @request_class ||= Struct.new(:format)
   end
 
-  described_class.hook_translation_helper(KeywordArgumentsHelper, middleware_enabled: true)
+  def controller_class
+    @controller_class ||= Struct.new(:request)
+  end
 
-  let(:view) { KeywordArgumentsView.new }
+  # NOTE: hook_translation_helper は渡されたモジュール自体を破壊的に変更する（alias_method 等）ため、
+  # view に include するモジュールと hook_translation_helper に渡すモジュールは同一オブジェクトである必要がある。
+  def keyword_arguments_helper
+    @keyword_arguments_helper ||=
+      Module.new do
+        attr_accessor :controller
+
+        # NOTE: ActionView の TranslationHelper を模し、.html/_html キーのみ html_safe な訳文を返す。
+        # マーカーは平文・html_safe どちらにも注入されるが、html_safe フラグの引き継ぎを検証できるよう両方返し分ける。
+        define_method(:translate) do |key, **options|
+          source = "Hello, #{options[:name]}"
+          key.to_s.end_with?('.html', '_html') ? source.html_safe : source
+        end
+      end
+  end
+
+  # NOTE: 実 HTML 描画では controller が存在し request.format が html になるため、
+  # デフォルトはそれを再現した controller を持たせておく。
+  let(:view) do
+    Class.new.include(keyword_arguments_helper).new.tap do |v|
+      v.controller = controller_class.new(request_class.new(format_class.new(:html)))
+    end
+  end
 
   before do
-    # NOTE: controller_of_rails_engine? は ::Rails::Engine への依存があり単体 spec では評価できないため、
-    # この spec の関心（注入ガード）に絞って常に false を返すようスタブする。
-    allow(CopyTunerClient::Rails).to receive(:controller_of_rails_engine?).and_return(false)
+    # NOTE: helper_extension が参照する CopyTunerClient::Rails は engine への依存があり
+    # 単体 spec では require できず、controller_of_rails_engine? も ::Rails::Engine への
+    # 依存があり単体 spec では評価できないため、この spec の関心（注入ガード）に絞って
+    # 常に false を返すフェイクモジュールに差し替える。
+    fake_rails_module = Module.new { def self.controller_of_rails_engine?(_controller) = false }
+    define_constant('CopyTunerClient::Rails', fake_rails_module)
+    described_class.hook_translation_helper(keyword_arguments_helper, middleware_enabled: true)
   end
 
   it 'works with keyword argument method' do
@@ -83,7 +84,7 @@ describe CopyTunerClient::HelperExtension do
 
     %i[json text csv pdf].each do |format|
       it "does not inject the marker when request.format is :#{format}" do
-        view.controller = Controller.new(Request.new(Format.new(format)))
+        view.controller = controller_class.new(request_class.new(format_class.new(format)))
         expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
       end
     end
@@ -102,13 +103,13 @@ describe CopyTunerClient::HelperExtension do
     end
 
     it 'does not inject the marker when the controller has no request' do
-      view.controller = Controller.new(nil)
+      view.controller = controller_class.new(nil)
       expect(view.translate('some.key', name: 'World')).to eq 'Hello, World'
     end
 
     it 'does not raise when ActionMailer is not loaded' do
       hide_const('ActionMailer::Base') if defined?(ActionMailer::Base)
-      view.controller = Controller.new(Request.new(Format.new(:html)))
+      view.controller = controller_class.new(request_class.new(format_class.new(:html)))
       expect { view.translate('some.key', name: 'World') }.not_to raise_error
     end
   end
@@ -117,7 +118,7 @@ describe CopyTunerClient::HelperExtension do
   # 維持されなければならない。注入ガードが初期値登録まで巻き添えで止めていないことを保証する。
   context 'default value registration' do
     it 'registers the default value even when the marker is not injected' do
-      view.controller = Controller.new(Request.new(Format.new(:json)))
+      view.controller = controller_class.new(request_class.new(format_class.new(:json)))
       expect(I18n).to receive(:t).with('some.key', hash_including(default: 'Default'))
       view.translate('some.key', name: 'World', default: 'Default')
     end

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -2,36 +2,38 @@ require 'spec_helper'
 
 describe 'CopyTunerClient::I18nBackend' do
   # テスト用のキャッシュクラス：既存のHashインターフェースを維持しつつ新機能をサポート
-  class TestCache < Hash
-    def initialize(initial_etag = 'test-etag-1')
-      super()
-      @test_etag = initial_etag
-    end
+  def test_cache_class
+    Class.new(Hash) do
+      def initialize(initial_etag = 'test-etag-1')
+        super()
+        @test_etag = initial_etag
+      end
 
-    def version
-      @test_etag
-    end
+      def version
+        @test_etag
+      end
 
-    def to_tree_hash
-      CopyTunerClient::DottedHash.to_h(self)
-    end
+      def to_tree_hash
+        CopyTunerClient::DottedHash.to_h(self)
+      end
 
-    def wait_for_download
-      # テスト用のスタブメソッド
-    end
+      def wait_for_download
+        # テスト用のスタブメソッド
+      end
 
-    def etag=(value)
-      @test_etag = value
-    end
+      def etag=(value)
+        @test_etag = value
+      end
 
-    def etag
-      @test_etag
+      def etag
+        @test_etag
+      end
     end
   end
 
   subject { build_backend }
 
-  let(:cache) { TestCache.new }
+  let(:cache) { test_cache_class.new }
 
   def build_backend
     backend = CopyTunerClient::I18nBackend.new(cache)
@@ -501,7 +503,7 @@ describe 'CopyTunerClient::I18nBackend' do
       end
 
       it 'views.* がローカルにも cache にも無いとき nil を返し、空キー登録（アップロード）をしないこと' do
-        spy_cache = TestCache.new
+        spy_cache = test_cache_class.new
         allow(spy_cache).to receive(:[]=).and_call_original
         backend = CopyTunerClient::I18nBackend.new(spy_cache)
         I18n.backend = backend

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -1,14 +1,16 @@
 require 'spec_helper'
 
 describe CopyTunerClient::Poller do
-  POLLING_DELAY = 0.5
-
   let(:client) { FakeClient.new }
   let(:cache) { CopyTunerClient::Cache.new(client, logger: FakeLogger.new) }
 
+  def polling_delay
+    0.5
+  end
+
   def build_poller(config = {})
     config[:logger] ||= FakeLogger.new
-    config[:polling_delay] = POLLING_DELAY
+    config[:polling_delay] = polling_delay
     default_config = CopyTunerClient::Configuration.new.to_hash
     poller = CopyTunerClient::Poller.new(cache, default_config.update(config))
     @pollers << poller
@@ -16,7 +18,7 @@ describe CopyTunerClient::Poller do
   end
 
   def wait_for_next_sync
-    sleep(POLLING_DELAY * 3)
+    sleep(polling_delay * 3)
   end
 
   before do


### PR DESCRIPTION
## Summary
- spec の describe ブロック直下で定義していた定数・クラス・モジュール（Format/Request/Controller、KeywordArgumentsHelper/KeywordArgumentsView、TestCache、POLLING_DELAY）を、describe 内のメモ化メソッドに変換
- CopyTunerClient::Rails の再オープンは既存の DefinesConstants#define_constant（stub_const のラッパー）に統一
- hook_translation_helper が渡されたモジュール自体を破壊的に変更するため、keyword_arguments_helper はメモ化を維持し、view 作成時に controller のデフォルト値を都度セットする形に変更
- .rubocop_todo.yml から該当2 Cop のエントリを削除

## Test plan
- [x] `bundle exec rspec` で関連 spec が GREEN
- [x] `bundle exec rubocop` でプロジェクト全体の違反ゼロ