### PR TITLE
fix: RuboCop RSpec/NamedSubject の違反を解消する

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,19 +38,6 @@ RSpec/MessageSpies:
     - 'spec/copy_tuner_client/request_sync_spec.rb'
     - 'spec/copy_tuner_client_spec.rb'
 
-# Offense count: 96
-# Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
-# SupportedStyles: always, named_only
-RSpec/NamedSubject:
-  Exclude:
-    - 'spec/copy_tuner_client/cache_spec.rb'
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-    - 'spec/copy_tuner_client/copyray_spec.rb'
-    - 'spec/copy_tuner_client/dotted_hash_spec.rb'
-    - 'spec/copy_tuner_client/i18n_backend_spec.rb'
-    - 'spec/copy_tuner_client/prefixed_logger_spec.rb'
-    - 'spec/copy_tuner_client/request_sync_spec.rb'
-
 # Offense count: 6
 RSpec/StubbedMock:
   Exclude:

--- a/spec/copy_tuner_client/cache_spec.rb
+++ b/spec/copy_tuner_client/cache_spec.rb
@@ -284,7 +284,7 @@ describe 'CopyTunerClient::Cache' do
   end
 
   describe '#to_tree_hash' do
-    subject { cache.to_tree_hash }
+    subject(:tree_hash) { cache.to_tree_hash }
 
     let(:cache) do
       cache = build_cache
@@ -293,7 +293,7 @@ describe 'CopyTunerClient::Cache' do
     end
 
     it 'データがない場合は空ハッシュを返すこと' do
-      expect(subject).to eq({})
+      expect(tree_hash).to eq({})
     end
 
     context 'フラットなキーの場合' do
@@ -304,17 +304,17 @@ describe 'CopyTunerClient::Cache' do
       end
 
       it 'ツリー構造に変換されること' do
-        expect(subject).to eq({
-                                'ja' => {
-                                  'views' => {
-                                    'hoge' => 'test',
-                                    'fuga' => 'test2',
+        expect(tree_hash).to eq({
+                                  'ja' => {
+                                    'views' => {
+                                      'hoge' => 'test',
+                                      'fuga' => 'test2',
+                                    },
                                   },
-                                },
-                                'en' => {
-                                  'hello' => 'world',
-                                },
-                              })
+                                  'en' => {
+                                    'hello' => 'world',
+                                  },
+                                })
       end
     end
 
@@ -327,26 +327,26 @@ describe 'CopyTunerClient::Cache' do
       end
 
       it '正しいツリー構造になること' do
-        expect(subject).to eq({
-                                'ja' => {
-                                  'views' => {
-                                    'users' => {
-                                      'index' => 'user index',
-                                      'show' => 'user show',
-                                    },
-                                    'posts' => {
-                                      'index' => 'post index',
-                                    },
-                                  },
-                                },
-                                'en' => {
-                                  'common' => {
-                                    'buttons' => {
-                                      'save' => 'Save',
+        expect(tree_hash).to eq({
+                                  'ja' => {
+                                    'views' => {
+                                      'users' => {
+                                        'index' => 'user index',
+                                        'show' => 'user show',
+                                      },
+                                      'posts' => {
+                                        'index' => 'post index',
+                                      },
                                     },
                                   },
-                                },
-                              })
+                                  'en' => {
+                                    'common' => {
+                                      'buttons' => {
+                                        'save' => 'Save',
+                                      },
+                                    },
+                                  },
+                                })
       end
     end
   end
@@ -392,7 +392,7 @@ describe 'CopyTunerClient::Cache' do
   end
 
   describe '#export' do
-    subject { cache.export }
+    subject(:export_result) { cache.export }
 
     let(:cache) do
       cache = build_cache
@@ -410,7 +410,7 @@ describe 'CopyTunerClient::Cache' do
     end
 
     it 'blurbキーがない場合はyamlを返さないこと' do
-      expect(subject).to be_nil
+      expect(export_result).to be_nil
     end
 
     context '1階層のblurbキーがある場合' do

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 shared_context 'stubbed configuration' do
-  subject { CopyTunerClient::Configuration.new }
+  subject(:configuration) { CopyTunerClient::Configuration.new }
 
   let(:backend) { double('i18n-backend') }
   let(:cache) { double('cache', download: 'download') }
@@ -15,10 +15,10 @@ shared_context 'stubbed configuration' do
     allow(CopyTunerClient::Cache).to receive(:new).and_return(cache)
     allow(CopyTunerClient::Poller).to receive(:new).and_return(poller)
     allow(CopyTunerClient::ProcessGuard).to receive(:new).and_return(process_guard)
-    subject.logger = logger
+    configuration.logger = logger
     # NOTE: apply は project_id 必須になったため、未設定だと raise する。applied 系テストは
     #       project_id 自体を検証しないので適当な値を補っておく
-    subject.project_id ||= 1
+    configuration.project_id ||= 1
     apply
   end
 end
@@ -34,12 +34,12 @@ shared_examples_for 'applied configuration' do
   end
 
   it 'builds and assigns a poller' do
-    expect(CopyTunerClient::Poller).to have_received(:new).with(cache, subject.to_hash)
+    expect(CopyTunerClient::Poller).to have_received(:new).with(cache, configuration.to_hash)
   end
 
   it 'builds a process guard' do
     expect(CopyTunerClient::ProcessGuard).to have_received(:new)
-      .with(cache, poller, subject.to_hash)
+      .with(cache, poller, configuration.to_hash)
   end
 
   it 'logs that it is ready' do
@@ -47,11 +47,13 @@ shared_examples_for 'applied configuration' do
   end
 
   it 'logs environment info' do
-    expect(logger).to have_entry(:info, "Environment Info: #{subject.environment_info}")
+    expect(logger).to have_entry(:info, "Environment Info: #{configuration.environment_info}")
   end
 end
 
 describe CopyTunerClient::Configuration do
+  subject(:configuration) { described_class.new }
+
   RSpec::Matchers.define :have_config_option do |option|
     match do |config|
       expect(config).to respond_to(option)
@@ -220,14 +222,14 @@ describe CopyTunerClient::Configuration do
   end
 
   it 'generates environment info without a framework' do
-    subject.environment_name = 'production'
-    expect(subject.environment_info).to eq("[Ruby: #{RUBY_VERSION}] [Env: production]")
+    configuration.environment_name = 'production'
+    expect(configuration.environment_info).to eq("[Ruby: #{RUBY_VERSION}] [Env: production]")
   end
 
   it 'generates environment info with a framework' do
-    subject.environment_name = 'production'
-    subject.framework = 'Sinatra: 1.0.0'
-    expect(subject.environment_info)
+    configuration.environment_name = 'production'
+    configuration.framework = 'Sinatra: 1.0.0'
+    expect(configuration.environment_info)
       .to eq("[Ruby: #{RUBY_VERSION}] [Sinatra: 1.0.0] [Env: production]")
   end
 
@@ -333,8 +335,8 @@ describe CopyTunerClient::Configuration do
     end
 
     def apply
-      subject.environment_name = 'test'
-      subject.apply
+      configuration.environment_name = 'test'
+      configuration.apply
     end
   end
 
@@ -346,8 +348,8 @@ describe CopyTunerClient::Configuration do
     end
 
     def apply
-      subject.environment_name = 'development'
-      subject.apply
+      configuration.environment_name = 'development'
+      configuration.apply
     end
   end
 
@@ -361,9 +363,9 @@ describe CopyTunerClient::Configuration do
     let(:middleware) { MiddlewareStack.new }
 
     def apply
-      subject.middleware = middleware
-      subject.environment_name = 'development'
-      subject.apply
+      configuration.middleware = middleware
+      configuration.environment_name = 'development'
+      configuration.apply
     end
   end
 
@@ -371,9 +373,9 @@ describe CopyTunerClient::Configuration do
     it_behaves_like 'applied configuration'
 
     def apply
-      subject.middleware = nil
-      subject.environment_name = 'development'
-      subject.apply
+      configuration.middleware = nil
+      configuration.environment_name = 'development'
+      configuration.apply
     end
   end
 
@@ -383,9 +385,9 @@ describe CopyTunerClient::Configuration do
     it_behaves_like 'applied configuration'
 
     def apply
-      subject.middleware = middleware
-      subject.environment_name = 'test'
-      subject.apply
+      configuration.middleware = middleware
+      configuration.environment_name = 'test'
+      configuration.apply
     end
 
     it 'does not add the sync middleware' do
@@ -397,11 +399,11 @@ describe CopyTunerClient::Configuration do
     include_context 'stubbed configuration'
 
     def apply
-      subject.apply
+      configuration.apply
     end
 
     it 'has locales [:en]' do
-      expect(subject.locales).to eq [:en]
+      expect(configuration.locales).to eq [:en]
     end
   end
 
@@ -409,12 +411,12 @@ describe CopyTunerClient::Configuration do
     include_context 'stubbed configuration'
 
     def apply
-      subject.locales = %i[en ja]
-      subject.apply
+      configuration.locales = %i[en ja]
+      configuration.apply
     end
 
     it 'has locales %i(en ja)' do
-      expect(subject.locales).to eq %i[en ja]
+      expect(configuration.locales).to eq %i[en ja]
     end
   end
 
@@ -430,7 +432,7 @@ describe CopyTunerClient::Configuration do
     end
 
     def apply
-      subject.apply
+      configuration.apply
     end
 
     context 'with available_locales' do
@@ -438,7 +440,7 @@ describe CopyTunerClient::Configuration do
       include_context 'stubbed configuration'
 
       it 'has locales %i(en ja)' do
-        expect(subject.locales).to eq %i[en ja]
+        expect(configuration.locales).to eq %i[en ja]
       end
     end
 
@@ -447,7 +449,7 @@ describe CopyTunerClient::Configuration do
       include_context 'stubbed configuration'
 
       it 'has locales %i(ja)' do
-        expect(subject.locales).to eq %i[ja]
+        expect(configuration.locales).to eq %i[ja]
       end
     end
   end

--- a/spec/copy_tuner_client/copyray_spec.rb
+++ b/spec/copy_tuner_client/copyray_spec.rb
@@ -3,7 +3,7 @@ require 'copy_tuner_client/copyray'
 
 describe CopyTunerClient::Copyray do
   describe '.augment_template' do
-    subject { described_class.augment_template(source, key) }
+    subject(:augmented) { described_class.augment_template(source, key) }
 
     let(:key) { 'en.test.key' }
 
@@ -18,11 +18,11 @@ describe CopyTunerClient::Copyray do
       let(:source) { FakeHtmlSafeString.new('<b>Hello</b>').html_safe }
 
       it 'keeps the html_safe flag so the translation is not re-escaped' do
-        expect(subject).to be_html_safe
+        expect(augmented).to be_html_safe
       end
 
       it 'prepends the visible marker token without escaping' do
-        expect(subject).to eq '⟦CT:en.test.key⟧<b>Hello</b>'
+        expect(augmented).to eq '⟦CT:en.test.key⟧<b>Hello</b>'
       end
     end
 
@@ -30,8 +30,8 @@ describe CopyTunerClient::Copyray do
       let(:source) { FakeHtmlSafeString.new('Hello & <World>') }
 
       it 'prepends the marker but keeps the source non html_safe so ActionView still escapes the body' do
-        expect(subject).to eq '⟦CT:en.test.key⟧Hello & <World>'
-        expect(subject).not_to be_html_safe
+        expect(augmented).to eq '⟦CT:en.test.key⟧Hello & <World>'
+        expect(augmented).not_to be_html_safe
       end
     end
 

--- a/spec/copy_tuner_client/dotted_hash_spec.rb
+++ b/spec/copy_tuner_client/dotted_hash_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CopyTunerClient::DottedHash do
   describe '.to_h' do
-    subject { described_class.to_h(dotted_hash) }
+    subject(:converted_hash) { described_class.to_h(dotted_hash) }
 
     context '空のキーの場合' do
       let(:dotted_hash) { {} }
@@ -32,19 +32,19 @@ describe CopyTunerClient::DottedHash do
       end
 
       it '正しくネストされたハッシュに変換されること' do
-        expect(subject).to eq({
-                                'en' => {
-                                  'test' => {
-                                    'key' => 'en test value',
-                                    'other_key' => 'en other test value',
-                                  },
-                                },
-                                'fr' => {
-                                  'test' => {
-                                    'key' => 'fr test value',
-                                  },
-                                },
-                              })
+        expect(converted_hash).to eq({
+                                       'en' => {
+                                         'test' => {
+                                           'key' => 'en test value',
+                                           'other_key' => 'en other test value',
+                                         },
+                                       },
+                                       'fr' => {
+                                         'test' => {
+                                           'key' => 'fr test value',
+                                         },
+                                       },
+                                     })
       end
     end
 
@@ -71,18 +71,18 @@ describe CopyTunerClient::DottedHash do
       end
 
       it '型変換せず値を文字列のまま保持する' do
-        expect(subject).to eq({
-                                'en' => {
-                                  'number' => { 'currency' => { 'format' => { 'precision' => '2' } } },
-                                  'custom' => { 'precision' => 'custom_value' },
-                                },
-                              })
+        expect(converted_hash).to eq({
+                                       'en' => {
+                                         'number' => { 'currency' => { 'format' => { 'precision' => '2' } } },
+                                         'custom' => { 'precision' => 'custom_value' },
+                                       },
+                                     })
       end
     end
   end
 
   describe '.conflict_keys' do
-    subject { described_class.conflict_keys(dotted_hash) }
+    subject(:conflicts) { described_class.conflict_keys(dotted_hash) }
 
     context '有効なキーの場合' do
       let(:dotted_hash) do
@@ -107,10 +107,10 @@ describe CopyTunerClient::DottedHash do
       end
 
       it '競合するキーが正しく検出されること' do
-        expect(subject).to eq({
-                                'ja.fuga.test' => %w[ja.fuga.test.hoge],
-                                'ja.hoge.test' => %w[ja.hoge.test.fuga ja.hoge.test.hoge],
-                              })
+        expect(conflicts).to eq({
+                                  'ja.fuga.test' => %w[ja.fuga.test.hoge],
+                                  'ja.hoge.test' => %w[ja.hoge.test.fuga ja.hoge.test.hoge],
+                                })
       end
     end
   end

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -31,7 +31,7 @@ describe 'CopyTunerClient::I18nBackend' do
     end
   end
 
-  subject { build_backend }
+  subject(:backend) { build_backend }
 
   let(:cache) { test_cache_class.new }
 
@@ -50,12 +50,12 @@ describe 'CopyTunerClient::I18nBackend' do
   it 'ロケールファイルをリロードし、ダウンロード完了まで待機すること' do
     expect(I18n).to receive(:load_path).and_return([])
     # wait_for_downloadはTestCacheクラス内で呼ばれる
-    subject.reload!
-    subject.translate('en', 'test.key', default: 'something')
+    backend.reload!
+    backend.translate('en', 'test.key', default: 'something')
   end
 
   it 'i18nのBaseバックエンドを継承していること' do
-    expect(subject).to be_a(I18n::Backend::Base)
+    expect(backend).to be_a(I18n::Backend::Base)
   end
 
   it 'キャッシュからキーを検索できること' do
@@ -74,13 +74,13 @@ describe 'CopyTunerClient::I18nBackend' do
     cache['en.key'] = ''
     cache['fr.key'] = ''
 
-    expect(subject.available_locales).to contain_exactly(:en, :es, :fr)
+    expect(backend.available_locales).to contain_exactly(:en, :es, :fr)
   end
 
   it 'default付きで未登録キーをキューイングすること' do
     default = 'default value'
 
-    expect(subject.translate('en', 'test.key', default:)).to eq(default)
+    expect(backend.translate('en', 'test.key', default:)).to eq(default)
 
     expect(cache['en.test.key']).to eq(default)
   end
@@ -88,13 +88,13 @@ describe 'CopyTunerClient::I18nBackend' do
   it 'defaultが配列（文字列1つ）の場合も未登録キーをキューイングすること' do
     default = 'default value'
 
-    expect(subject.translate('en', 'test.key', default: [default])).to eq(default)
+    expect(backend.translate('en', 'test.key', default: [default])).to eq(default)
 
     expect(cache['en.test.key']).to eq(default)
   end
 
   it 'defaultなしで未登録キーをキューイングすること' do
-    expect { subject.translate('en', 'test.key') }
+    expect { backend.translate('en', 'test.key') }
       .to throw_symbol(:exception)
 
     expect(cache).to have_key 'en.test.key'
@@ -104,7 +104,7 @@ describe 'CopyTunerClient::I18nBackend' do
   it 'scope付きで未登録キーをキューイングすること' do
     default = 'default value'
 
-    expect(subject.translate('en', 'key', default:, scope: ['test']))
+    expect(backend.translate('en', 'key', default:, scope: ['test']))
       .to eq(default)
 
     expect(cache['en.test.key']).to eq(default)
@@ -113,30 +113,30 @@ describe 'CopyTunerClient::I18nBackend' do
   it 'defaultがシンボルの場合は未登録キーをキューイングしないこと' do
     cache['en.key.one'] = 'Expected'
 
-    expect(subject.translate('en', 'key.three', default: :'key.one')).to eq 'Expected'
+    expect(backend.translate('en', 'key.three', default: :'key.one')).to eq 'Expected'
 
     expect(cache).to have_key 'en.key.three'
     expect(cache['en.key.three']).to be_nil
 
-    expect(subject.translate('en', 'key.three', default: :'key.one')).to eq 'Expected'
+    expect(backend.translate('en', 'key.three', default: :'key.one')).to eq 'Expected'
   end
 
   it 'defaultが配列（シンボル含む）の場合は未登録キーをキューイングしないこと' do
     cache['en.key.one'] = 'Expected'
 
-    expect(subject.translate('en', 'key.three', default: %i[key.two key.one])).to eq 'Expected'
+    expect(backend.translate('en', 'key.three', default: %i[key.two key.one])).to eq 'Expected'
 
     expect(cache).to have_key 'en.key.three'
     expect(cache['en.key.three']).to be_nil
 
-    expect(subject.translate('en', 'key.three', default: %i[key.two key.one])).to eq 'Expected'
+    expect(backend.translate('en', 'key.three', default: %i[key.two key.one])).to eq 'Expected'
   end
 
   it '補間付きで未登録キーをキューイングすること' do
     # I18n の補間構文 %{interpolate} であり Kernel#format 用の printf トークンではないため annotated 化は不適切
     default = 'default %{interpolate}' # rubocop:disable Style/FormatStringToken
 
-    expect(subject.translate('en', 'test.key', default:, interpolate: 'interpolated')).to eq 'default interpolated'
+    expect(backend.translate('en', 'test.key', default:, interpolate: 'interpolated')).to eq 'default interpolated'
 
     expect(cache['en.test.key']).to eq 'default %{interpolate}' # rubocop:disable Style/FormatStringToken
   end
@@ -164,65 +164,61 @@ describe 'CopyTunerClient::I18nBackend' do
 
   context '非文字列キーの場合' do
     it 'キャッシュに登録されないこと' do
-      expect { subject.translate('en', {}) }.to throw_symbol(:exception)
+      expect { backend.translate('en', {}) }.to throw_symbol(:exception)
       expect(cache).not_to have_key 'en.{}'
     end
   end
 
   describe 'store_translations利用時' do
-    subject { build_backend }
-
     it 'store_translationsで登録した値をdefaultとして利用できること' do
-      subject.store_translations('en', 'test' => { 'key' => 'Expected' })
-      expect(subject.translate('en', 'test.key', default: 'Unexpected'))
+      backend.store_translations('en', 'test' => { 'key' => 'Expected' })
+      expect(backend.translate('en', 'test.key', default: 'Unexpected'))
         .to include('Expected')
       expect(cache['en.test.key']).to eq('Expected')
     end
 
     it '補間マーカーを保持したまま保存できること' do
       # I18n の補間構文 %{interpolate} であり Kernel#format 用の printf トークンではないため annotated 化は不適切
-      subject.store_translations('en', 'test' => { 'key' => '%{interpolate}' }) # rubocop:disable Style/FormatStringToken
-      expect(subject.translate('en', 'test.key', interpolate: 'interpolated'))
+      backend.store_translations('en', 'test' => { 'key' => '%{interpolate}' }) # rubocop:disable Style/FormatStringToken
+      expect(backend.translate('en', 'test.key', interpolate: 'interpolated'))
         .to include('interpolated')
       expect(cache['en.test.key']).to eq('%{interpolate}') # rubocop:disable Style/FormatStringToken
     end
 
     it 'store_translationsでキーがなければdefaultを利用すること' do
-      expect(subject.translate('en', 'test.key', default: 'Expected'))
+      expect(backend.translate('en', 'test.key', default: 'Expected'))
         .to include('Expected')
     end
 
     it 'キャッシュにキーがあればそちらを優先すること' do
-      subject.store_translations('en', 'test' => { 'key' => 'Unexpected' })
+      backend.store_translations('en', 'test' => { 'key' => 'Unexpected' })
       cache['en.test.key'] = 'Expected'
-      expect(subject.translate('en', 'test.key', default: 'default'))
+      expect(backend.translate('en', 'test.key', default: 'default'))
         .to include('Expected')
     end
 
     it 'ネストしたハッシュを保存できること' do
       nested = { nested: 'value' }
-      subject.store_translations('en', 'key' => nested)
-      expect(subject.translate('en', 'key', default: 'Unexpected')).to eq(nested)
+      backend.store_translations('en', 'key' => nested)
+      expect(backend.translate('en', 'key', default: 'Unexpected')).to eq(nested)
       expect(cache['en.key.nested']).to eq('value')
     end
 
     it '配列はそのまま返しキャッシュしないこと' do
       array = ['value']
-      subject.store_translations('en', 'key' => array)
-      expect(subject.translate('en', 'key', default: 'Unexpected')).to eq(array)
+      backend.store_translations('en', 'key' => array)
+      expect(backend.translate('en', 'key', default: 'Unexpected')).to eq(array)
       expect(cache['en.key']).to be_nil
     end
 
     it 'defaultが配列の場合に順に検索できること' do
-      subject.store_translations('en', 'key' => { 'one' => 'Expected' })
-      expect(subject.translate('en', 'key.three', default: %i[key.two key.one]))
+      backend.store_translations('en', 'key' => { 'one' => 'Expected' })
+      expect(backend.translate('en', 'key.three', default: %i[key.two key.one]))
         .to include('Expected')
     end
   end
 
   describe 'Fallbacks利用時' do
-    subject { build_backend }
-
     before do
       CopyTunerClient::I18nBackend.class_eval do
         include I18n::Backend::Fallbacks
@@ -231,7 +227,7 @@ describe 'CopyTunerClient::I18nBackend' do
 
     it 'defaultとFallbacks併用時はキャッシュにデフォルト値を入れないこと' do
       default = 'default value'
-      expect(subject.translate('en', 'test.key', default:)).to eq(default)
+      expect(backend.translate('en', 'test.key', default:)).to eq(default)
 
       # default と Fallbacks を併用した場合、キャッシュにデフォルト値は入らない仕様に変えた
       # その仕様にしないと、うまく Fallbacks の処理が動かないため
@@ -242,14 +238,12 @@ describe 'CopyTunerClient::I18nBackend' do
 
   # NOTE: 色々考慮する必要があることが分かったため暫定対応として、ツリーキャッシュを使用しないようにしている
   describe 'ツリー構造のlookup' do
-    subject { build_backend }
-
     context '完全一致が存在する場合' do
       it 'ツリー構造より完全一致を優先すること' do
         cache['ja.views.hoge'] = 'exact_value'
         cache['ja.views.hoge.sub'] = 'sub_value'
 
-        result = subject.translate('ja', 'views.hoge')
+        result = backend.translate('ja', 'views.hoge')
         expect(result).to eq('exact_value')
       end
     end
@@ -260,7 +254,7 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.views.fuga'] = 'test2'
         cache['ja.other.key'] = 'other'
 
-        result = subject.translate('ja', 'views')
+        result = backend.translate('ja', 'views')
         expect(result).to eq({
                                hoge: 'test',
                                fuga: 'test2',
@@ -270,7 +264,7 @@ describe 'CopyTunerClient::I18nBackend' do
       it '存在しない部分キーはnilを返すこと' do
         cache['ja.views.hoge'] = 'test'
 
-        result = subject.translate('ja', 'nonexistent', default: nil)
+        result = backend.translate('ja', 'nonexistent', default: nil)
         expect(result).to be_nil
       end
 
@@ -279,7 +273,7 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.views.users.show'] = 'user show'
         cache['ja.views.posts.index'] = 'post index'
 
-        result = subject.translate('ja', 'views')
+        result = backend.translate('ja', 'views')
         expect(result).to eq({
                                users: {
                                  index: 'user index',
@@ -301,18 +295,18 @@ describe 'CopyTunerClient::I18nBackend' do
       end
 
       it '完全一致を正しく扱うこと' do
-        expect(subject.translate('ja', 'views.hoge')).to eq('exact_hoge')
+        expect(backend.translate('ja', 'views.hoge')).to eq('exact_hoge')
       end
 
       it 'ツリー構造を正しく扱うこと' do
-        expect(subject.translate('ja', 'views.fuga')).to eq({
+        expect(backend.translate('ja', 'views.fuga')).to eq({
                                                               one: 'one',
                                                               two: 'two',
                                                             })
       end
 
       it 'より深い完全一致も正しく扱うこと' do
-        expect(subject.translate('ja', 'views.hoge.sub')).to eq('sub_value')
+        expect(backend.translate('ja', 'views.hoge.sub')).to eq('sub_value')
       end
     end
 
@@ -322,7 +316,7 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.views.fuga'] = 'test2'
 
         # 最初のlookupでツリーキャッシュが構築される
-        result = subject.translate('ja', 'views')
+        result = backend.translate('ja', 'views')
         expect(result).to eq({
                                hoge: 'test',
                                fuga: 'test2',
@@ -333,25 +327,25 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.views.hoge'] = 'test'
 
         # 1回目
-        subject.translate('ja', 'views')
+        backend.translate('ja', 'views')
 
         # ツリーキャッシュの再構築が発生しないことを確認
         expect(cache).not_to receive(:to_tree_hash)
 
         # 2回目
-        subject.translate('ja', 'views')
+        backend.translate('ja', 'views')
       end
 
       it 'キャッシュバージョンが変わった場合はツリーキャッシュを再構築すること' do
         cache['ja.views.hoge'] = 'test'
-        subject.translate('ja', 'views')
+        backend.translate('ja', 'views')
 
         # ETag（バージョン）を変更してキャッシュを更新
         cache.etag = '"new_etag"'
 
         # 新しい値を追加
         cache['ja.views.new'] = 'new value'
-        result = subject.translate('ja', 'views')
+        result = backend.translate('ja', 'views')
         expect(result).to include(new: 'new value')
       end
 
@@ -359,7 +353,7 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.views.test'] = 'value'
         cache.etag = nil
 
-        result = subject.translate('ja', 'views')
+        result = backend.translate('ja', 'views')
         expect(result).to eq({ test: 'value' })
       end
     end
@@ -372,14 +366,14 @@ describe 'CopyTunerClient::I18nBackend' do
         end
 
         # 初回のツリーキャッシュ構築
-        subject.translate('ja', 'category1')
+        backend.translate('ja', 'category1')
 
         # ETag が変わらない限り、再構築されない
         expect(cache).not_to receive(:to_tree_hash)
 
         # 複数回の lookup が高速で実行される
         start_time = Time.now
-        10.times { subject.translate('ja', 'category2') }
+        10.times { backend.translate('ja', 'category2') }
         end_time = Time.now
 
         # 10ms 以下で完了することを確認
@@ -389,14 +383,14 @@ describe 'CopyTunerClient::I18nBackend' do
 
     context 'エッジケース' do
       it '空キャッシュでも正常に動作すること' do
-        result = subject.translate('ja', 'views', default: nil)
+        result = backend.translate('ja', 'views', default: nil)
         expect(result).to be_nil
       end
 
       it '1階層のキーも正常に扱えること' do
         cache['ja.simple'] = 'simple value'
 
-        result = subject.translate('ja', 'simple')
+        result = backend.translate('ja', 'simple')
         expect(result).to eq('simple value')
       end
 
@@ -413,13 +407,13 @@ describe 'CopyTunerClient::I18nBackend' do
         expect(handler).to receive(:call).with(instance_of(CopyTunerClient::IgnoredKey))
 
         # ignored_keys が動作することを確認
-        subject.translate('ja', 'views.secret')
+        backend.translate('ja', 'views.secret')
       end
 
       it 'stringキーが存在する場合のsub-keyアクセスでエラーが発生しないこと' do
         cache['ja.hoge'] = 'hoge value'
 
-        result = subject.translate('ja', 'hoge.hello', default: nil)
+        result = backend.translate('ja', 'hoge.hello', default: nil)
         expect(result).to be_nil
       end
 
@@ -429,15 +423,15 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.dummy'] = 'dummy'
 
         expect {
-          subject.translate('ja', 'enumerize.infection_control.body_temperature.36.5', default: nil)
+          backend.translate('ja', 'enumerize.infection_control.body_temperature.36.5', default: nil)
         }.not_to raise_error
       end
 
       it '数値セグメントキーが存在しても通常キーのlookupが壊れないこと' do
         cache['ja.views.hoge'] = 'normal'
 
-        expect { subject.translate('ja', 'enumerize.body_temperature.36.5', default: nil) }.not_to raise_error
-        expect(subject.translate('ja', 'views.hoge')).to eq('normal')
+        expect { backend.translate('ja', 'enumerize.body_temperature.36.5', default: nil) }.not_to raise_error
+        expect(backend.translate('ja', 'views.hoge')).to eq('normal')
       end
     end
   end
@@ -461,9 +455,9 @@ describe 'CopyTunerClient::I18nBackend' do
       it 'views.* でも従来どおり copy_tuner（cache）を優先すること' do
         CopyTunerClient.configuration.local_first_key_regexp = nil
         cache['ja.views.foo'] = 'copy tuner value'
-        store_local(subject, :ja, views: { foo: 'local value' })
+        store_local(backend, :ja, views: { foo: 'local value' })
 
-        expect(subject.translate('ja', 'views.foo')).to eq('copy tuner value')
+        expect(backend.translate('ja', 'views.foo')).to eq('copy tuner value')
       end
 
       # NOTE: number.*.format は precision 等の非文字列値が store_item で落ちるため、
@@ -471,17 +465,17 @@ describe 'CopyTunerClient::I18nBackend' do
       it 'number.*.format は cache に値があってもローカル YAML を優先すること' do
         CopyTunerClient.configuration.local_first_key_regexp = nil
         cache['ja.number.currency.format.unit'] = '$'
-        store_local(subject, :ja, number: { currency: { format: { unit: '円' } } })
+        store_local(backend, :ja, number: { currency: { format: { unit: '円' } } })
 
-        expect(subject.translate('ja', 'number.currency.format')).to eq(unit: '円')
+        expect(backend.translate('ja', 'number.currency.format')).to eq(unit: '円')
       end
 
       it 'アプリ独自の number キーは従来どおり copy_tuner を優先すること' do
         CopyTunerClient.configuration.local_first_key_regexp = nil
         cache['ja.number.gift_amount'] = 'copy tuner value'
-        store_local(subject, :ja, number: { gift_amount: 'local value' })
+        store_local(backend, :ja, number: { gift_amount: 'local value' })
 
-        expect(subject.translate('ja', 'number.gift_amount')).to eq('copy tuner value')
+        expect(backend.translate('ja', 'number.gift_amount')).to eq('copy tuner value')
       end
     end
 
@@ -490,16 +484,16 @@ describe 'CopyTunerClient::I18nBackend' do
 
       it 'views.* は cache に値があってもローカル YAML を優先すること' do
         cache['ja.views.foo'] = 'copy tuner value'
-        store_local(subject, :ja, views: { foo: 'local value' })
+        store_local(backend, :ja, views: { foo: 'local value' })
 
-        expect(subject.translate('ja', 'views.foo')).to eq('local value')
+        expect(backend.translate('ja', 'views.foo')).to eq('local value')
       end
 
       it 'views.* 以外のキーは従来どおり copy_tuner を優先すること' do
         cache['ja.messages.foo'] = 'copy tuner value'
-        store_local(subject, :ja, messages: { foo: 'local value' })
+        store_local(backend, :ja, messages: { foo: 'local value' })
 
-        expect(subject.translate('ja', 'messages.foo')).to eq('copy tuner value')
+        expect(backend.translate('ja', 'messages.foo')).to eq('copy tuner value')
       end
 
       it 'views.* がローカルにも cache にも無いとき nil を返し、空キー登録（アップロード）をしないこと' do

--- a/spec/copy_tuner_client/prefixed_logger_spec.rb
+++ b/spec/copy_tuner_client/prefixed_logger_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
 describe CopyTunerClient::PrefixedLogger do
-  subject { described_class.new(prefix, output_logger) }
+  subject(:prefixed_logger) { described_class.new(prefix, output_logger) }
 
   let(:output_logger) { FakeLogger.new }
   let(:prefix) { '** NOTICE:' }
   let(:thread_info) { "[P:#{Process.pid}] [T:#{Thread.current.object_id}]" }
 
   it 'provides the prefix' do
-    expect(subject.prefix).to eq(prefix)
+    expect(prefixed_logger.prefix).to eq(prefix)
   end
 
   it 'provides the logger' do
-    expect(subject.original_logger).to eq(output_logger)
+    expect(prefixed_logger.original_logger).to eq(output_logger)
   end
 
   %i[debug info warn error fatal].each do |level|
     it "prefixes #{level} log messages" do
       message = 'hello'
-      subject.send(level, message)
+      prefixed_logger.send(level, message)
 
       expect(output_logger).to have_entry(level, "#{prefix} #{thread_info} #{message}")
     end
@@ -27,10 +27,10 @@ describe CopyTunerClient::PrefixedLogger do
   it 'calls flush for a logger that responds to flush' do
     expect(output_logger).to receive(:flush)
 
-    subject.flush
+    prefixed_logger.flush
   end
 
   it "doesn't call flush for a logger that doesn't respond to flush" do
-    expect { subject.flush }.not_to raise_error
+    expect { prefixed_logger.flush }.not_to raise_error
   end
 end

--- a/spec/copy_tuner_client/request_sync_spec.rb
+++ b/spec/copy_tuner_client/request_sync_spec.rb
@@ -12,19 +12,19 @@ describe CopyTunerClient::RequestSync do
   end
 
   context 'interval が 0 の場合' do
-    subject { described_class.new(app, poller:, cache:, interval: 0) }
+    subject(:request_sync) { described_class.new(app, poller:, cache:, interval: 0) }
 
     let(:env) { 'env' }
 
     it 'invokes the upstream app' do
       expect(app).to receive(:call).with(env)
-      result = subject.call(env)
+      result = request_sync.call(env)
       expect(result).to eq(response)
     end
   end
 
   context 'when serving assets' do
-    subject { described_class.new(app, poller:, cache:, interval: 0) }
+    subject(:request_sync) { described_class.new(app, poller:, cache:, interval: 0) }
 
     let(:env) do
       { 'PATH_INFO' => '/assets/choper.png' }
@@ -32,42 +32,42 @@ describe CopyTunerClient::RequestSync do
 
     it "don't start sync" do
       expect(cache).to receive(:download).once
-      subject.call(env)
+      request_sync.call(env)
       expect(poller).not_to receive(:start_sync)
-      subject.call(env)
+      request_sync.call(env)
     end
   end
 
   context 'interval が 10 の場合' do
-    subject { described_class.new(app, poller:, cache:, interval: 10) }
+    subject(:request_sync) { described_class.new(app, poller:, cache:, interval: 10) }
 
     let(:env) { 'env' }
 
     context 'first request' do
       it 'download' do
         expect(cache).to receive(:download).once
-        subject.call(env)
+        request_sync.call(env)
       end
     end
 
     context 'in interval request' do
       it 'does not start sync for the second time' do
         expect(cache).to receive(:download).once
-        subject.call(env)
+        request_sync.call(env)
 
         expect(poller).not_to receive(:start_sync)
-        subject.call(env)
+        request_sync.call(env)
       end
     end
 
     context 'over interval request' do
       it 'start sync for the second time' do
         expect(cache).to receive(:download).once
-        subject.call(env)
+        request_sync.call(env)
 
         expect(poller).to receive(:start_sync).once
-        subject.last_synced = Time.now - 60
-        subject.call(env)
+        request_sync.last_synced = Time.now - 60
+        request_sync.call(env)
       end
     end
   end


### PR DESCRIPTION
## Summary
- RuboCop `RSpec/NamedSubject` の違反を解消（96件、7ファイル）
- 無名の `subject { ... }` に意味の分かる名前を付け（`tree_hash`, `configuration`, `backend` など）、参照箇所を置換
- `.rubocop_todo.yml` から `RSpec/NamedSubject` のエントリを削除

## Test plan
- [x] `bundle exec rubocop` で全体の違反ゼロを確認
- [x] 変更した7ファイルの関連 spec を実行し、全テスト成功を確認