### PR TITLE
fix: RuboCop RSpec/MessageSpies, RSpec/StubbedMock の違反を解消する

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,31 +21,6 @@ RSpec/InstanceVariable:
     - 'spec/copy_tuner_client/poller_spec.rb'
     - 'spec/copy_tuner_client/process_guard_spec.rb'
 
-# Offense count: 33
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: have_received, receive
-RSpec/MessageSpies:
-  Exclude:
-    - 'spec/copy_tuner_client/cache_spec.rb'
-    - 'spec/copy_tuner_client/client_spec.rb'
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-    - 'spec/copy_tuner_client/copyray/rewriter_spec.rb'
-    - 'spec/copy_tuner_client/helper_extension_spec.rb'
-    - 'spec/copy_tuner_client/i18n_backend_spec.rb'
-    - 'spec/copy_tuner_client/poller_spec.rb'
-    - 'spec/copy_tuner_client/prefixed_logger_spec.rb'
-    - 'spec/copy_tuner_client/process_guard_spec.rb'
-    - 'spec/copy_tuner_client/request_sync_spec.rb'
-    - 'spec/copy_tuner_client_spec.rb'
-
-# Offense count: 6
-RSpec/StubbedMock:
-  Exclude:
-    - 'spec/copy_tuner_client/cache_spec.rb'
-    - 'spec/copy_tuner_client/configuration_spec.rb'
-    - 'spec/copy_tuner_client/i18n_backend_spec.rb'
-    - 'spec/copy_tuner_client/poller_spec.rb'
-
 # Offense count: 14
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:

--- a/spec/copy_tuner_client/cache_spec.rb
+++ b/spec/copy_tuner_client/cache_spec.rb
@@ -157,7 +157,7 @@ describe 'CopyTunerClient::Cache' do
   it 'flush時に接続エラーが発生した場合はエラーログを出力すること' do
     failure = 'server is napping'
     logger = FakeLogger.new
-    expect(client).to receive(:upload).and_raise(CopyTunerClient::ConnectionError.new(failure))
+    allow(client).to receive(:upload).and_raise(CopyTunerClient::ConnectionError.new(failure))
     cache = build_cache(logger:)
     cache['upload.key'] = 'upload'
 
@@ -169,7 +169,7 @@ describe 'CopyTunerClient::Cache' do
   it 'download時に接続エラーが発生した場合はエラーログを出力すること' do
     failure = 'server is napping'
     logger = FakeLogger.new
-    expect(client).to receive(:download).and_raise(CopyTunerClient::ConnectionError.new(failure))
+    allow(client).to receive(:download).and_raise(CopyTunerClient::ConnectionError.new(failure))
     cache = build_cache(logger:, ready: true)
 
     cache.download
@@ -179,7 +179,7 @@ describe 'CopyTunerClient::Cache' do
 
   it '最初のダウンロードが完了するまでブロックすること' do
     logger = FakeLogger.new
-    expect(logger).to receive(:flush)
+    allow(logger).to receive(:flush)
     client.delay = true
     cache = build_cache(logger:)
 
@@ -195,6 +195,7 @@ describe 'CopyTunerClient::Cache' do
     expect(t_download.join(1)).not_to be_nil
     expect(cache).not_to be_pending
     expect(t_wait.join(1)).not_to be_nil
+    expect(logger).to have_received(:flush)
   end
 
   it 'ダウンロード前はブロックしないこと' do
@@ -278,9 +279,11 @@ describe 'CopyTunerClient::Cache' do
       config.project_id = 1
       config.cache = cache
     end
-    expect(cache).to receive(:flush).at_least(:once)
+    allow(cache).to receive(:flush)
 
     CopyTunerClient.flush
+
+    expect(cache).to have_received(:flush).at_least(:once)
   end
 
   describe '#to_tree_hash' do
@@ -405,8 +408,10 @@ describe 'CopyTunerClient::Cache' do
         config.project_id = 1
         config.cache = cache
       end
-      expect(cache).to receive(:export)
+      allow(cache).to receive(:export)
       CopyTunerClient.export
+
+      expect(cache).to have_received(:export)
     end
 
     it 'blurbキーがない場合はyamlを返さないこと' do

--- a/spec/copy_tuner_client/client_spec.rb
+++ b/spec/copy_tuner_client/client_spec.rb
@@ -209,9 +209,11 @@ describe 'CopyTunerClient' do
       config.project_id = 1
       config.client = client
     end
-    expect(client).to receive(:deploy)
+    allow(client).to receive(:deploy)
 
     CopyTunerClient.deploy
+
+    expect(client).to have_received(:deploy)
   end
 
   it 'deployが実行できること' do

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -216,7 +216,7 @@ describe CopyTunerClient::Configuration do
 
   it 'logs to $stdout by default' do
     logger = FakeLogger.new
-    expect(Logger).to receive(:new).with($stdout).and_return(logger)
+    allow(Logger).to receive(:new).with($stdout).and_return(logger)
     config = described_class.new
     expect(config.logger.original_logger).to eq(logger)
   end
@@ -330,7 +330,7 @@ describe CopyTunerClient::Configuration do
   context 'applied when testing' do
     it_behaves_like 'applied configuration' do
       it 'does not start the process guard' do
-        expect(process_guard).not_to receive(:start)
+        expect(process_guard).not_to have_received(:start)
       end
     end
 

--- a/spec/copy_tuner_client/copyray/rewriter_spec.rb
+++ b/spec/copy_tuner_client/copyray/rewriter_spec.rb
@@ -192,8 +192,9 @@ describe CopyTunerClient::Copyray::Rewriter do
       it 'logger.warn で例外内容を記録する' do
         logger = double('logger')
         allow(CopyTunerClient.configuration).to receive(:logger).and_return(logger)
-        expect(logger).to receive(:warn).with(/Rewriter failed.*RuntimeError.*boom/)
+        allow(logger).to receive(:warn)
         result
+        expect(logger).to have_received(:warn).with(/Rewriter failed.*RuntimeError.*boom/)
       end
 
       it 'logger が nil でもフォールバックが落ちない' do

--- a/spec/copy_tuner_client/helper_extension_spec.rb
+++ b/spec/copy_tuner_client/helper_extension_spec.rb
@@ -119,8 +119,9 @@ describe CopyTunerClient::HelperExtension do
   context 'default value registration' do
     it 'registers the default value even when the marker is not injected' do
       view.controller = controller_class.new(request_class.new(format_class.new(:json)))
-      expect(I18n).to receive(:t).with('some.key', hash_including(default: 'Default'))
+      allow(I18n).to receive(:t)
       view.translate('some.key', name: 'World', default: 'Default')
+      expect(I18n).to have_received(:t).with('some.key', hash_including(default: 'Default'))
     end
   end
 end

--- a/spec/copy_tuner_client/i18n_backend_spec.rb
+++ b/spec/copy_tuner_client/i18n_backend_spec.rb
@@ -48,10 +48,11 @@ describe 'CopyTunerClient::I18nBackend' do
   after { I18n.backend = @default_backend }
 
   it 'ロケールファイルをリロードし、ダウンロード完了まで待機すること' do
-    expect(I18n).to receive(:load_path).and_return([])
+    allow(I18n).to receive(:load_path).and_return([])
     # wait_for_downloadはTestCacheクラス内で呼ばれる
     backend.reload!
     backend.translate('en', 'test.key', default: 'something')
+    expect(I18n).to have_received(:load_path)
   end
 
   it 'i18nのBaseバックエンドを継承していること' do
@@ -330,10 +331,12 @@ describe 'CopyTunerClient::I18nBackend' do
         backend.translate('ja', 'views')
 
         # ツリーキャッシュの再構築が発生しないことを確認
-        expect(cache).not_to receive(:to_tree_hash)
+        allow(cache).to receive(:to_tree_hash)
 
         # 2回目
         backend.translate('ja', 'views')
+
+        expect(cache).not_to have_received(:to_tree_hash)
       end
 
       it 'キャッシュバージョンが変わった場合はツリーキャッシュを再構築すること' do
@@ -369,13 +372,14 @@ describe 'CopyTunerClient::I18nBackend' do
         backend.translate('ja', 'category1')
 
         # ETag が変わらない限り、再構築されない
-        expect(cache).not_to receive(:to_tree_hash)
+        allow(cache).to receive(:to_tree_hash)
 
         # 複数回の lookup が高速で実行される
         start_time = Time.now
         10.times { backend.translate('ja', 'category2') }
         end_time = Time.now
 
+        expect(cache).not_to have_received(:to_tree_hash)
         # 10ms 以下で完了することを確認
         expect((end_time - start_time) * 1000).to be < 10
       end
@@ -404,10 +408,12 @@ describe 'CopyTunerClient::I18nBackend' do
         cache['ja.views.secret'] = 'secret'
 
         # ignored_key_handler が呼ばれることを確認
-        expect(handler).to receive(:call).with(instance_of(CopyTunerClient::IgnoredKey))
+        allow(handler).to receive(:call)
 
         # ignored_keys が動作することを確認
         backend.translate('ja', 'views.secret')
+
+        expect(handler).to have_received(:call).with(instance_of(CopyTunerClient::IgnoredKey))
       end
 
       it 'stringキーが存在する場合のsub-keyアクセスでエラーが発生しないこと' do

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -64,7 +64,7 @@ describe CopyTunerClient::Poller do
     failure = 'server is napping'
     logger = FakeLogger.new
 
-    expect(cache).to receive(:download).and_raise(CopyTunerClient::InvalidApiKey.new(failure))
+    allow(cache).to receive(:download).and_raise(CopyTunerClient::InvalidApiKey.new(failure))
     poller = build_poller(logger:)
 
     cache['upload.key'] = 'upload'
@@ -80,7 +80,7 @@ describe CopyTunerClient::Poller do
   end
 
   it "logs an error if the background thread can't start" do
-    expect(Thread).to receive(:new).and_return(nil)
+    allow(Thread).to receive(:new).and_return(nil)
     logger = FakeLogger.new
 
     build_poller(logger:).start
@@ -90,10 +90,12 @@ describe CopyTunerClient::Poller do
 
   it 'flushes the log when polling' do
     logger = FakeLogger.new
-    expect(logger).to receive(:flush).at_least(:once)
+    allow(logger).to receive(:flush)
 
     build_poller(logger:).start
 
     wait_for_next_sync
+
+    expect(logger).to have_received(:flush).at_least(:once)
   end
 end

--- a/spec/copy_tuner_client/prefixed_logger_spec.rb
+++ b/spec/copy_tuner_client/prefixed_logger_spec.rb
@@ -25,9 +25,11 @@ describe CopyTunerClient::PrefixedLogger do
   end
 
   it 'calls flush for a logger that responds to flush' do
-    expect(output_logger).to receive(:flush)
+    allow(output_logger).to receive(:flush)
 
     prefixed_logger.flush
+
+    expect(output_logger).to have_received(:flush)
   end
 
   it "doesn't call flush for a logger that doesn't respond to flush" do

--- a/spec/copy_tuner_client/process_guard_spec.rb
+++ b/spec/copy_tuner_client/process_guard_spec.rb
@@ -24,13 +24,13 @@ describe CopyTunerClient::ProcessGuard do
   end
 
   it 'starts polling from a worker process' do
-    expect(poller).to receive(:start)
     process_guard = build_process_guard
     process_guard.start
+
+    expect(poller).to have_received(:start)
   end
 
   it 'registers passenger hooks from the passenger master' do
-    expect(poller).not_to receive(:start)
     logger = FakeLogger.new
     passenger = define_constant('PhusionPassenger', FakePassenger.new)
     passenger.become_master
@@ -38,11 +38,11 @@ describe CopyTunerClient::ProcessGuard do
     process_guard = build_process_guard(logger:)
     process_guard.start
 
+    expect(poller).not_to have_received(:start)
     expect(logger).to have_entry(:info, 'Registered Phusion Passenger fork hook')
   end
 
   it 'starts polling from a passenger worker' do
-    expect(poller).to receive(:start)
     logger = FakeLogger.new
     passenger = define_constant('PhusionPassenger', FakePassenger.new)
     passenger.become_master
@@ -50,10 +50,11 @@ describe CopyTunerClient::ProcessGuard do
 
     process_guard.start
     passenger.spawn
+
+    expect(poller).to have_received(:start)
   end
 
   it 'registers unicorn hooks from the unicorn master' do
-    expect(poller).not_to receive(:start)
     logger = FakeLogger.new
     define_constant('Unicorn', Module.new)
     http_server = Class.new(FakeUnicornServer)
@@ -63,11 +64,11 @@ describe CopyTunerClient::ProcessGuard do
     process_guard = build_process_guard(logger:)
     process_guard.start
 
+    expect(poller).not_to have_received(:start)
     expect(logger).to have_entry(:info, 'Registered Unicorn fork hook')
   end
 
   it 'starts polling from a unicorn worker' do
-    expect(poller).to receive(:start)
     logger = FakeLogger.new
     define_constant('Unicorn', Module.new)
     http_server = Class.new(FakeUnicornServer)
@@ -77,6 +78,8 @@ describe CopyTunerClient::ProcessGuard do
 
     process_guard.start
     unicorn.spawn
+
+    expect(poller).to have_received(:start)
   end
 
   it 'flushes when the process terminates' do

--- a/spec/copy_tuner_client/request_sync_spec.rb
+++ b/spec/copy_tuner_client/request_sync_spec.rb
@@ -17,8 +17,8 @@ describe CopyTunerClient::RequestSync do
     let(:env) { 'env' }
 
     it 'invokes the upstream app' do
-      expect(app).to receive(:call).with(env)
       result = request_sync.call(env)
+      expect(app).to have_received(:call).with(env)
       expect(result).to eq(response)
     end
   end
@@ -31,10 +31,11 @@ describe CopyTunerClient::RequestSync do
     end
 
     it "don't start sync" do
-      expect(cache).to receive(:download).once
       request_sync.call(env)
-      expect(poller).not_to receive(:start_sync)
       request_sync.call(env)
+
+      expect(cache).to have_received(:download).once
+      expect(poller).not_to have_received(:start_sync)
     end
   end
 
@@ -45,29 +46,30 @@ describe CopyTunerClient::RequestSync do
 
     context 'first request' do
       it 'download' do
-        expect(cache).to receive(:download).once
         request_sync.call(env)
+        expect(cache).to have_received(:download).once
       end
     end
 
     context 'in interval request' do
       it 'does not start sync for the second time' do
-        expect(cache).to receive(:download).once
+        request_sync.call(env)
         request_sync.call(env)
 
-        expect(poller).not_to receive(:start_sync)
-        request_sync.call(env)
+        expect(cache).to have_received(:download).once
+        expect(poller).not_to have_received(:start_sync)
       end
     end
 
     context 'over interval request' do
       it 'start sync for the second time' do
-        expect(cache).to receive(:download).once
         request_sync.call(env)
 
-        expect(poller).to receive(:start_sync).once
         request_sync.last_synced = Time.now - 60
         request_sync.call(env)
+
+        expect(cache).to have_received(:download).once
+        expect(poller).to have_received(:start_sync).once
       end
     end
   end

--- a/spec/copy_tuner_client_spec.rb
+++ b/spec/copy_tuner_client_spec.rb
@@ -6,12 +6,12 @@ describe CopyTunerClient do
   end
 
   it 'delegates cache to the configuration object' do
-    expect(described_class.configuration).to receive(:cache).once
     expect(described_class.cache).to eq('cache')
+    expect(described_class.configuration).to have_received(:cache).once
   end
 
   it 'delegates client to the configuration object' do
-    expect(described_class.configuration).to receive(:client).once
     expect(described_class.client).to eq('client')
+    expect(described_class.configuration).to have_received(:client).once
   end
 end


### PR DESCRIPTION
## Summary
- `expect(...).to receive(...)` によるメッセージ期待を spy パターン（`allow` + `have_received`）へ変換し、`RSpec/MessageSpies` / `RSpec/StubbedMock` の違反を解消
- 負の期待（`not_to receive`）も `not_to have_received` に統一
- `.rubocop_todo.yml` から該当2 Cop のエントリを削除

## Test plan
- [x] `bundle exec rubocop` で違反ゼロを確認
- [x] 影響を受けた11 spec ファイルを実行し 263 examples, 0 failures を確認