### PR TITLE
[review] fix: Devise 併用時に認証エラーで Copyray マーカーが残る不具合を修正する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+- **【後方互換性に影響】** Devise（Warden）併用時に認証エラーで Copyray マーカー（`⟦CT:key⟧`）がページに
+  残る不具合を修正しました。`throw :warden` は `Warden::Manager` の `catch(:warden)` までスタックを巻き
+  戻すため、CopyTuner の middleware が Warden より内側にあると `Devise::FailureApp` が返す HTML を書き換え
+  られませんでした。`Warden::Manager` と `Devise` がどちらも定義されている場合、CopyTuner の
+  middleware（`RequestSync` / `CopyrayMiddleware`）のデフォルト挿入位置をその直前に変更しました
+  （`Warden::Manager` をスタックへ積むのは Devise なので、warden を require するだけの gem では
+  既定位置を変えません）。Devise を使っていない環境では従来どおりスタック
+  末尾に追加されます。Devise を使っているアプリでは CopyTuner の middleware の位置が変わるため、
+  `config.middleware.use` で自作 middleware を追加している場合、相対順序が変わる可能性があります。
+  `config.middleware_position` を明示的に指定している場合はその指定が優先されるため、挙動は変わりません。
+- `config.middleware_position = { after: SomeMiddleware }` を指定した場合に `RequestSync` と
+  `CopyrayMiddleware` の順序が逆になっていた不具合を修正しました。
 - **【後方互換性に影響】** `config.exclude_key_regexp` を削除しました。後継の `config.local_first_key_regexp`
   を使ってください。両者は対象キーの形式が異なります（`exclude_key_regexp` は locale 付き `ja.views.foo`、
   `local_first_key_regexp` は locale を除いた `views.foo`）。正規表現から locale プレフィックスを外して

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ CopyTuner で一元管理している翻訳を、`views.*` のような単位で
 
 アプリ独自の `number.*` キー（例 `number.gift_amount`）は対象外で、従来どおり CopyTuner で管理できます。
 
+## Middleware の挿入位置
+
+CopyTuner は開発環境で `RequestSync` / `CopyrayMiddleware` を Rack の middleware スタックに挿入します。`RequestSync` はリクエスト毎に CopyTuner サーバと同期し、`CopyrayMiddleware` はページ内のマーカー（`⟦CT:key⟧`）を除去・変換します。
+
+挿入位置は自動で決まるため、通常は設定不要です。Devise（Warden）を使っているアプリでは `Warden::Manager` の直前、それ以外の環境ではスタック末尾に挿入されます。
+
+Devise 併用時に Warden の直前へ寄せるのは `throw :warden` の挙動に対応するためです。`throw :warden` は `Warden::Manager` の `catch(:warden)` までスタックを巻き戻すため、CopyTuner の middleware が Warden より内側にあると、認証エラー時のレスポンス（`Devise::FailureApp` が返す HTML）を受け取れず、Copyray のマーカーがページに残ってしまいます。
+
+位置を変えたい場合は `config.middleware_position` に `{ before: SomeMiddleware }` または `{ after: SomeMiddleware }` を指定すると、このデフォルトを上書きできます。
+
+```ruby
+CopyTunerClient.configure do |config|
+  # ...
+  config.middleware_position = { after: Rack::Runtime }
+end
+```
+
+指定した middleware がスタックに存在しない場合、Rails の起動時に例外（`No such middleware to insert before: ...` / `... insert after: ...`）が発生します。
+
 ## Claude Code スキル
 
 `skills/copy-tuner/` に Claude Code 向けのスキルが含まれています。

--- a/lib/copy_tuner_client/configuration.rb
+++ b/lib/copy_tuner_client/configuration.rb
@@ -184,6 +184,7 @@ module CopyTunerClient
       self.local_first_key_regexp = nil
       self.project_id = nil
       self.download_cache_dir = Pathname.new(Dir.pwd).join('tmp', 'cache', 'copy_tuner_client')
+      self.middleware_position = default_middleware_position
 
       @applied = false
     end
@@ -357,6 +358,20 @@ module CopyTunerClient
       end
     end
 
+    # throw :warden は Warden::Manager の catch(:warden) までスタックを巻き戻すため、
+    # Warden より内側の middleware は @app.call の戻り値を受け取れず、Devise::FailureApp の
+    # 応答がマーカー除去を経ずにブラウザへ届いてしまう。これを避けるため Warden の直前を既定位置にする。
+    #
+    # 判定に Devise の有無も見るのは、warden を require するだけで Warden::Manager を
+    # スタックに積まない gem（authtrail 等）が存在するため。定数の有無だけで決めると
+    # そうしたアプリで insert_before が対象を見つけられず起動時例外になる。
+    # スタックへ積むのは Devise の railtie（config.app_middleware.use）である。
+    def default_middleware_position
+      return nil unless defined?(::Warden::Manager) && defined?(::Devise)
+
+      { before: ::Warden::Manager }
+    end
+
     def setup_middleware
       if enable_middleware?
         logger.info 'Using copytuner sync middleware'
@@ -372,23 +387,33 @@ module CopyTunerClient
       logger.info "Available locales: #{locales.join(' ')}"
     end
 
-    def insert_middleware # rubocop:disable Metrics/AbcSize
-      request_sync_options = {
+    def insert_middleware
+      # NOTE: 値の nil を除外するのは、{ before: SomeClass if cond } のように条件次第で nil が入る
+      # 書き方で従来は末尾 use にフォールバックしていた挙動を保つため（キーの有無だけで分岐すると
+      # insert_before(nil) が対象を見つけられず例外になる）。
+      case middleware_position
+      in { before: target } if target
+        middleware.insert_before(target, RequestSync, request_sync_options)
+        middleware.insert_before(target, CopyTunerClient::CopyrayMiddleware)
+      in { after: target } if target
+        # NOTE: insert_after(index, *) は insert(index + 1, *) を呼ぶため、同じ対象へ 2 回挿入すると
+        # 後から挿入した方が対象に近い位置に来て順序が反転する。逆順で呼ぶことで
+        # 外側→内側が RequestSync → CopyrayMiddleware に揃う。
+        middleware.insert_after(target, CopyTunerClient::CopyrayMiddleware)
+        middleware.insert_after(target, RequestSync, request_sync_options)
+      else
+        middleware.use(RequestSync, request_sync_options)
+        middleware.use(CopyTunerClient::CopyrayMiddleware)
+      end
+    end
+
+    def request_sync_options
+      {
         poller: @poller,
         cache:,
         interval: sync_interval,
         ignore_regex: sync_ignore_path_regex,
       }
-      if middleware_position.is_a?(Hash) && middleware_position[:before]
-        middleware.insert_before(middleware_position[:before], RequestSync, request_sync_options)
-        middleware.insert_before(middleware_position[:before], CopyTunerClient::CopyrayMiddleware)
-      elsif middleware_position.is_a?(Hash) && middleware_position[:after]
-        middleware.insert_after(middleware_position[:after], RequestSync, request_sync_options)
-        middleware.insert_after(middleware_position[:after], CopyTunerClient::CopyrayMiddleware)
-      else
-        middleware.use(RequestSync, request_sync_options)
-        middleware.use(CopyTunerClient::CopyrayMiddleware)
-      end
     end
 
     # project_id は必須。未設定なら明示的に失敗させる。

--- a/spec/copy_tuner_client/configuration_spec.rb
+++ b/spec/copy_tuner_client/configuration_spec.rb
@@ -398,6 +398,179 @@ describe CopyTunerClient::Configuration do
     end
   end
 
+  describe 'middleware_position の初期値' do
+    let(:config) { described_class.new }
+
+    context 'Warden::Manager と Devise がどちらも定義済みのとき' do
+      before do
+        stub_const('Warden::Manager', Class.new)
+        stub_const('Devise', Module.new)
+      end
+
+      it '{ before: Warden::Manager } になる' do
+        expect(config.middleware_position).to eq({ before: Warden::Manager })
+      end
+    end
+
+    context 'Warden::Manager が未定義のとき' do
+      before { hide_const('Warden::Manager') }
+
+      it 'nil のままになる' do
+        expect(config.middleware_position).to be_nil
+      end
+    end
+
+    # NOTE: authtrail のように warden を require するだけで Warden::Manager をスタックへ積まない
+    # gem があるため、Warden 単独では既定位置にしない（insert_before が起動時例外になる）。
+    context 'Warden::Manager は定義済みだが Devise が未定義のとき' do
+      before do
+        stub_const('Warden::Manager', Class.new)
+        hide_const('Devise')
+      end
+
+      it 'nil のままになる' do
+        expect(config.middleware_position).to be_nil
+      end
+    end
+
+    context 'configure ブロック内で明示指定したとき' do
+      before do
+        stub_const('Warden::Manager', Class.new)
+        stub_const('Devise', Module.new)
+      end
+
+      it '明示指定した値が優先される' do
+        other = Class.new
+        CopyTunerClient.configure(apply: false) do |c|
+          c.middleware_position = { before: other }
+        end
+        expect(CopyTunerClient.configuration.middleware_position).to eq({ before: other })
+      end
+    end
+  end
+
+  context 'Warden::Manager がスタックにある状態で apply したとき' do
+    it_behaves_like 'applied configuration' do
+      it 'デフォルト値経由で Warden::Manager の直前に RequestSync → CopyrayMiddleware の順で入る' do
+        expect(middleware.classes).to eq(
+          [
+            Rack::ETag, Rack::TempfileReaper, CopyTunerClient::RequestSync, CopyTunerClient::CopyrayMiddleware,
+            Warden::Manager, Rack::Static
+          ]
+        )
+      end
+
+      it 'Warden::Manager より外側に配置される' do
+        expect(middleware.index(CopyTunerClient::RequestSync)).to be < middleware.index(Warden::Manager)
+        expect(middleware.index(CopyTunerClient::CopyrayMiddleware)).to be < middleware.index(Warden::Manager)
+      end
+
+      it 'RequestSync に poller / cache / interval / ignore_regex が渡る' do
+        args = middleware.args_for(CopyTunerClient::RequestSync)
+        expect(args.first).to include(
+          poller:, # rubocop:disable Sgcop/Rspec/NoMethodCallInExpectation
+          cache:,
+          interval: configuration.sync_interval,
+          ignore_regex: configuration.sync_ignore_path_regex
+        )
+      end
+    end
+
+    # NOTE: 実アプリの bin/rails middleware 出力を模した標準スタック。Warden::Manager / Devise は
+    # gem の依存にないため stub_const で fake の定数として定義する。
+    before do
+      stub_const('Warden::Manager', Class.new)
+      stub_const('Devise', Module.new)
+    end
+
+    let(:middleware) do
+      MiddlewareStack.new([Rack::ETag, Rack::TempfileReaper, Warden::Manager, Rack::Static])
+    end
+
+    def apply
+      configuration.middleware = middleware
+      configuration.environment_name = 'development'
+      configuration.apply
+    end
+  end
+
+  context 'Warden::Manager が未定義の状態で apply したとき' do
+    it_behaves_like 'applied configuration' do
+      it 'Warden::Manager 未定義時は従来どおりスタック末尾へ use される' do
+        expect(middleware.classes).to eq([CopyTunerClient::RequestSync, CopyTunerClient::CopyrayMiddleware])
+      end
+    end
+
+    before { hide_const('Warden::Manager') }
+
+    let(:middleware) { MiddlewareStack.new }
+
+    def apply
+      configuration.middleware = middleware
+      configuration.environment_name = 'development'
+      configuration.apply
+    end
+  end
+
+  context 'middleware_position に after を明示指定して apply したとき' do
+    it_behaves_like 'applied configuration' do
+      it '{after: X} 指定時は X の直後に RequestSync → CopyrayMiddleware の順で入る' do
+        expect(middleware.classes).to eq(
+          [:a, :x, CopyTunerClient::RequestSync, CopyTunerClient::CopyrayMiddleware, :b]
+        )
+      end
+    end
+
+    let(:middleware) { MiddlewareStack.new(%i[a x b]) }
+
+    def apply
+      configuration.middleware = middleware
+      configuration.middleware_position = { after: :x }
+      configuration.environment_name = 'development'
+      configuration.apply
+    end
+  end
+
+  context 'middleware_position に before を明示指定して apply したとき' do
+    it_behaves_like 'applied configuration' do
+      it '{before: X} 指定時は X の直前に RequestSync → CopyrayMiddleware の順で入る' do
+        expect(middleware.classes).to eq(
+          [:a, CopyTunerClient::RequestSync, CopyTunerClient::CopyrayMiddleware, :x, :b]
+        )
+      end
+    end
+
+    let(:middleware) { MiddlewareStack.new(%i[a x b]) }
+
+    def apply
+      configuration.middleware = middleware
+      configuration.middleware_position = { before: :x }
+      configuration.environment_name = 'development'
+      configuration.apply
+    end
+  end
+
+  # NOTE: { before: SomeClass if cond } のように条件次第で値が nil になる書き方を想定する。
+  # キーの有無だけで分岐すると insert_before(nil) が対象を見つけられず例外になる。
+  context 'middleware_position の値が nil のとき' do
+    it_behaves_like 'applied configuration' do
+      it '例外を投げずスタック末尾へ use する' do
+        expect(middleware.classes).to eq(
+          [:a, :x, :b, CopyTunerClient::RequestSync, CopyTunerClient::CopyrayMiddleware]
+        )
+      end
+    end
+
+    let(:middleware) { MiddlewareStack.new(%i[a x b]) }
+
+    def apply
+      configuration.middleware = middleware
+      configuration.middleware_position = { before: nil }
+      configuration.environment_name = 'development'
+      configuration.apply
+    end
+  end
+
   context 'applied without locale filter' do
     include_context 'stubbed configuration'
 

--- a/spec/copy_tuner_client/warden_integration_spec.rb
+++ b/spec/copy_tuner_client/warden_integration_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+require 'copy_tuner_client/copyray_middleware'
+require 'copy_tuner_client/copyray'
+require 'copy_tuner_client/copyray/marker'
+require 'copy_tuner_client/translation_log'
+
+# Warden::Manager の catch(:warden) と failure app 呼び出しだけを模した fake（warden gem に依存しないため）
+class FakeWarden
+  def initialize(app, failure_app)
+    @app = app
+    @failure_app = failure_app
+  end
+
+  def call(env)
+    result = catch(:warden) { @app.call(env) }
+    result.is_a?(Array) ? result : @failure_app.call(env)
+  end
+end
+
+# NOTE: CopyrayMiddleware 単体ではなく、Warden 相当の fake との組み合わせ位置を検証するため
+# describe の第一引数はクラスではなく説明文にしている
+describe 'throw :warden と CopyrayMiddleware の位置関係' do # rubocop:disable RSpec/DescribeClass
+  def marker(key)
+    CopyTunerClient::Copyray::Marker.encode(key)
+  end
+
+  # NOTE: authenticate_user! 失敗を模す。throw :warden するとこの @app.call(env) は正常リターンせず、
+  # CopyrayMiddleware が内側にあると Rewriter.rewrite が実行されない。
+  let(:throwing_app) { ->(_env) { throw :warden } }
+  let(:failure_status) { 200 }
+  let(:failure_app) do
+    ->(_env) do
+      [failure_status, { 'Content-Type' => 'text/html' }, [failure_body]]
+    end
+  end
+  let(:failure_body) { "<html><body><p>#{marker('devise.failure.unauthenticated')}Please sign in</p></body></html>" }
+
+  before do
+    CopyTunerClient.configure do |configuration|
+      configuration.project_id = 1
+      configuration.client = FakeClient.new
+    end
+  end
+
+  # NOTE: append_js は Rails の ActionController::Base.helpers に依存するため、
+  # copyray_middleware_spec.rb と同じ手法で no-op スタブに差し替え、Rewriter の効果だけを見る。
+  def stub_append_js(middleware)
+    allow(middleware).to receive(:append_js) { |html, *| html }
+  end
+
+  context '内側構成（CopyrayMiddleware が Warden より内側）のとき' do
+    it 'マーカー ⟦CT: がレスポンスに残る（不具合の記録）' do
+      copyray = CopyTunerClient::CopyrayMiddleware.new(throwing_app)
+      stub_append_js(copyray)
+      warden = FakeWarden.new(copyray, failure_app)
+
+      _status, _headers, response = warden.call({})
+      result = response.join
+
+      expect(result).to match(CopyTunerClient::Copyray::Marker::SCAN_REGEXP)
+    end
+  end
+
+  context '外側構成（CopyrayMiddleware が Warden より外側）のとき' do
+    it 'マーカーが消え data-copyray-key に変換される' do
+      warden = FakeWarden.new(throwing_app, failure_app)
+      copyray = CopyTunerClient::CopyrayMiddleware.new(warden)
+      stub_append_js(copyray)
+
+      _status, _headers, response = copyray.call({})
+      result = response.join
+
+      expect(result).to include('data-copyray-key="devise.failure.unauthenticated"')
+      expect(result).not_to match(CopyTunerClient::Copyray::Marker::SCAN_REGEXP)
+    end
+
+    context 'failure app が 422 を返すとき（Devise.responder.error_status = :unprocessable_entity 相当）' do
+      let(:unprocessable_failure_app) do
+        ->(_env) { [422, { 'Content-Type' => 'text/html' }, [failure_body]] }
+      end
+
+      it 'マーカーが消え data-copyray-key に変換される' do
+        warden = FakeWarden.new(throwing_app, unprocessable_failure_app)
+        copyray = CopyTunerClient::CopyrayMiddleware.new(warden)
+        stub_append_js(copyray)
+
+        _status, _headers, response = copyray.call({})
+        result = response.join
+
+        expect(result).to include('data-copyray-key="devise.failure.unauthenticated"')
+        expect(result).not_to match(CopyTunerClient::Copyray::Marker::SCAN_REGEXP)
+      end
+    end
+  end
+end

--- a/spec/support/middleware_stack.rb
+++ b/spec/support/middleware_stack.rb
@@ -1,13 +1,47 @@
+# ActionDispatch::MiddlewareStack の挿入 API を模した fake（挿入順序と引数を検証するため）
 class MiddlewareStack
-  def initialize
-    @middlewares = []
+  Entry = Struct.new(:klass, :args)
+
+  def initialize(existing = [])
+    @middlewares = existing.map { |klass| Entry.new(klass, []) }
   end
 
-  def use(klass, *)
-    @middlewares << klass.new('fake_app', *)
+  def use(klass, *args)
+    @middlewares << Entry.new(klass, args)
+  end
+
+  def insert_before(target, klass, *args)
+    index = index_of!(target, 'before')
+    @middlewares.insert(index, Entry.new(klass, args))
+  end
+
+  def insert_after(target, klass, *args)
+    index = index_of!(target, 'after')
+    @middlewares.insert(index + 1, Entry.new(klass, args))
   end
 
   def include?(klass)
-    @middlewares.any?(klass)
+    classes.include?(klass)
+  end
+
+  def classes
+    @middlewares.map(&:klass)
+  end
+
+  def index(klass)
+    classes.index(klass)
+  end
+
+  def args_for(klass)
+    @middlewares.find { |entry| entry.klass == klass }&.args
+  end
+
+  private
+
+  def index_of!(target, where)
+    index = classes.index(target)
+    raise "No such middleware to insert #{where}: #{target.inspect}" if index.nil?
+
+    index
   end
 end


### PR DESCRIPTION
## Summary
- `throw :warden` は `Warden::Manager` の `catch(:warden)` までスタックを巻き戻すため、Warden より内側にいた `CopyrayMiddleware` が `@app.call` の戻り値を受け取れず、`Devise::FailureApp` が返す HTML のマーカー除去が実行されていなかった不具合を修正
- `Warden::Manager` と `Devise` がどちらも定義されている場合のみ、middleware のデフォルト挿入位置を Warden の直前に変更（`authtrail` のように warden を require するだけでスタックへ積まない gem での誤爆を避けるため、Devise の有無も判定に含める）
- `insert_middleware` を `case/in` へ書き換え、`{after:}` 指定時に `RequestSync` と `CopyrayMiddleware` の順序が反転していたバグと、値が `nil` のときのフォールバック喪失も合わせて修正

## Test plan
- [x] `bundle exec rspec`（341 examples, 0 failures）
- [x] `bundle exec rubocop`（違反なし）
- [ ] Devise 併用アプリで未ログイン時の認証エラーページに Copyray マーカーが表示されないことを確認