### PR TITLE
[review] fix: Puma cluster モードで poller が worker に引き継がれない不具合を修正する

### DIFF
--- a/lib/copy_tuner_client/poller.rb
+++ b/lib/copy_tuner_client/poller.rb
@@ -15,11 +15,17 @@ module CopyTunerClient
       @command_queue = CopyTunerClient::QueueWithTimeout.new
       @mutex         = Mutex.new
       @thread        = nil
+      @pid           = nil
     end
 
     def start
       @mutex.synchronize do
+        # スレッドは fork を越えて引き継がれないため、前プロセスの Thread オブジェクトは
+        # 死んでいるものとして捨て、張り直す
+        @thread = nil if forked?
+
         if @thread.nil?
+          @pid = Process.pid
           @logger.info 'start poller thread'
           @thread = Thread.new { poll } or logger.error("Couldn't start poller thread")
         end
@@ -28,9 +34,16 @@ module CopyTunerClient
 
     def stop
       @mutex.synchronize do
-        @command_queue.uniq_push(:stop)
-        @thread&.join
+        # fork 後の子プロセスで :stop を積むと、直後に start した新しいスレッドが 1 周目で
+        # それを pop して自分を止めてしまう。他プロセスのスレッドを join しても意味がないため、
+        # どちらも自プロセスのスレッドに対してのみ行う
+        unless forked?
+          @command_queue.uniq_push(:stop)
+          @thread&.join
+        end
+
         @thread = nil
+        @pid = nil
       end
     end
 
@@ -45,6 +58,10 @@ module CopyTunerClient
     private
 
     attr_reader :cache, :logger, :polling_delay
+
+    def forked?
+      !@pid.nil? && @pid != Process.pid
+    end
 
     def poll
       loop do

--- a/lib/copy_tuner_client/poller.rb
+++ b/lib/copy_tuner_client/poller.rb
@@ -34,12 +34,12 @@ module CopyTunerClient
 
     def stop
       @mutex.synchronize do
-        # fork 後の子プロセスで :stop を積むと、直後に start した新しいスレッドが 1 周目で
-        # それを pop して自分を止めてしまう。他プロセスのスレッドを join しても意味がないため、
-        # どちらも自プロセスのスレッドに対してのみ行う
-        unless forked?
+        # 積んだ :stop は pop されるまでキューに残るため、止める相手のスレッドが自プロセスに
+        # ある場合のみ積む。さもないと直後に start した新しいスレッドが 1 周目でそれを pop して
+        # 自分を止めてしまう（スレッド未起動のとき / fork 後の子プロセスのときが該当）
+        if @thread && !forked?
           @command_queue.uniq_push(:stop)
-          @thread&.join
+          @thread.join
         end
 
         @thread = nil

--- a/lib/copy_tuner_client/process_guard.rb
+++ b/lib/copy_tuner_client/process_guard.rb
@@ -4,6 +4,15 @@ module CopyTunerClient
   # processes and completing background jobs. Applications using the client
   # will not need to interact with this class directly.
   class ProcessGuard # rubocop:disable Metrics/ClassLength
+    # Puma::Runner#start_server は worker プロセス側で呼ばれるため、そこで poller を起動する。
+    # 匿名 Module だと prepend が重複するので名前付き定数にしている
+    module PumaStartServerHook
+      def start_server
+        CopyTunerClient.poller&.start
+        super
+      end
+    end
+
     # @param options [Hash]
     # @option options [Logger] :logger where errors should be logged
     def initialize(cache, poller, options)
@@ -17,8 +26,7 @@ module CopyTunerClient
       if spawner?
         register_spawn_hooks
       else
-        register_exit_hooks
-        start_polling
+        start_polling_locally
       end
     end
 
@@ -28,8 +36,13 @@ module CopyTunerClient
       @poller.start
     end
 
+    def start_polling_locally
+      register_exit_hooks
+      start_polling
+    end
+
     def spawner?
-      passenger_spawner? || unicorn_spawner? || delayed_job_spawner? || puma_spawner? || good_job_spawner?
+      passenger_spawner? || unicorn_spawner? || delayed_job_spawner? || good_job_spawner? || puma?
     end
 
     def passenger_spawner?
@@ -41,8 +54,17 @@ module CopyTunerClient
       defined?(Unicorn::HttpServer) && $PROGRAM_NAME.include?('unicorn') && caller.none? { |line| line.include?('worker_loop') }
     end
 
-    def puma_spawner?
-      defined?(Puma::Runner) && $PROGRAM_NAME.include?('puma')
+    def puma?
+      # $PROGRAM_NAME は `rails server` 起動では rails のパスのままで、master / single は
+      # Process.setproctitle を使うため puma を含まない。Puma の有無だけで判定する。
+      #
+      # この判定は rails console / rake / Sidekiq など Puma をサーバとして起動していない
+      # プロセスでも真になるが、それを許容している。Puma には「今 Rack サーバとして起動中か」を
+      # 判定する公開 API がなく、絞り込もうとすると $0 やヒューリスティックに頼ることになり、
+      # `rails server` 経由でフックが登録されないという元のバグを再発させるため。
+      # 非サーバプロセスで生じるコストは puma/launcher のロード（実測 60〜70ms）と
+      # prepend のみで、フック本体は start_server が呼ばれない限り発火しない。
+      defined?(Puma) ? true : false
     end
 
     def delayed_job_spawner?
@@ -62,12 +84,14 @@ module CopyTunerClient
         register_passenger_hook
       elsif unicorn_spawner?
         register_unicorn_hook
-      elsif puma_spawner?
-        register_puma_hook
       elsif delayed_job_spawner?
         register_delayed_hook
       elsif good_job_spawner?
         register_good_job_hook
+      # puma? は Puma gem がロードされていれば真になり、Web サーバ以外のプロセスでも
+      # 該当してしまう。プロセスを特定できる判定を先に通し、最後の受け皿にする
+      elsif puma?
+        register_puma_hook
       end
     end
 
@@ -116,26 +140,41 @@ module CopyTunerClient
     end
 
     def register_puma_hook
-      # If Puma is clustered mode without preload_app, this method is called on worker process.
-      # Just start poller and return.
-      if $PROGRAM_NAME.include?('cluster worker')
-        @logger.info('Puma would be clustered mode without preload_app')
-        @poller.start
-        return
+      # cluster モードでは master でも worker でもこのメソッドが呼ばれる。worker 側で
+      # 確実に poller を動かすため、Puma::Runner#start_server にフックを仕掛ける
+      if load_puma_runner
+        ::Puma::Runner.prepend(PumaStartServerHook)
+        @logger.info('Registered Puma fork hook')
+      else
+        @logger.warn('Puma fork hook was not registered')
       end
 
-      @logger.info('Register Puma fork hook')
-      # If Puma is clustered mode with preload_app, this method is called before fork.
-      # Delay poller start until Puma::Runner#start_server which is called on worker process.
-      poller = @poller
-      hook_module =
-        Module.new do
-          define_method :start_server do
-            poller.start
-            super() # NOTE: define_method 内で super を呼ぶ場合は引数を明示的に指定する必要があるので注意
-          end
-        end
-      Puma::Runner.prepend(hook_module)
+      # single モードや従来 spawner 判定が外れていた `rails server` 経由での挙動を保つため、
+      # フック登録の成否に関わらず自プロセスでも poller を起動する。
+      #
+      # cluster の master もここを通るため、リクエストを捌かない master でも poller が 1 本立つ。
+      # master と worker を区別するには $0 や Puma の内部状態を見るしかなく、そこを間違えると
+      # single モードで poller が起動しなくなる。master 1 本の余分なポーリングを払う代わりに、
+      # どの起動方法・モードでも必ず poller が立つことを優先している
+      # （worker 側は Poller#start が pid の変化を見て張り直すため二重にはならない）。
+      start_polling_locally
+    end
+
+    # Puma::Runner は lib/puma.rb の autoload に含まれず puma/launcher の require で
+    # 初めて定義される。`rails server` では initializer 時点で未定義なので前倒しでロードする。
+    # puma/launcher のロードは定数定義のみでスレッド生成や signal trap を伴わず、Puma で
+    # 起動する場合はサーバ起動時に Puma 自身が同じ require を行うため実質的な前倒しに過ぎない
+    def load_puma_runner
+      return true if defined?(::Puma::Runner)
+
+      # puma/launcher 単体の require は Puma::HAS_NATIVE_IO_WAIT 未定義で NameError になるため
+      # puma を先にロードする
+      require 'puma'
+      require 'puma/launcher'
+      defined?(::Puma::Runner) ? true : false
+    rescue LoadError, NameError => e
+      @logger.warn("Could not load Puma::Runner: #{e.message}")
+      false
     end
 
     def register_exit_hooks

--- a/lib/copy_tuner_client/version.rb
+++ b/lib/copy_tuner_client/version.rb
@@ -1,6 +1,6 @@
 module CopyTunerClient
   # Client version
-  VERSION = '2.2.1'.freeze
+  VERSION = '2.3.0'.freeze
 
   # API version being used to communicate with the server
   API_VERSION = '2.0'.freeze

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -96,6 +96,21 @@ describe CopyTunerClient::Poller do
     expect(logger).to have_received(:flush).at_least(:once)
   end
 
+  it 'start していないときに stop してもキューに :stop を残さない' do
+    poller = build_poller
+    poller.stop
+
+    poller.start
+
+    # 1 周目の sync だけでは「:stop がキューに残っている」状態と区別できないため、
+    # 2 周目以降も同期が続くことを確かめる
+    wait_for_next_sync
+    client['test.key'] = 'value'
+    wait_for_next_sync
+
+    expect(cache['test.key']).to eq('value')
+  end
+
   describe 'fork をまたいだ場合' do
     # Thread.new を実行させると poller スレッドが後始末されずテストを跨いで残るため、
     # 分岐ロジックだけを見るためにダミーを返す

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -26,7 +26,7 @@ describe CopyTunerClient::Poller do
     pollers.each(&:stop)
   end
 
-  it 'polls after being started' do
+  it 'start した後はポーリングする' do
     poller = build_poller
     poller.start
 
@@ -36,7 +36,7 @@ describe CopyTunerClient::Poller do
     expect(cache['test.key']).to eq('value')
   end
 
-  it "doesn't poll before being started" do
+  it 'start する前はポーリングしない' do
     build_poller
     client['test.key'] = 'value'
 
@@ -45,7 +45,7 @@ describe CopyTunerClient::Poller do
     expect(cache['test.key']).to be_nil
   end
 
-  it 'stops polling when stopped' do
+  it 'stop するとポーリングを停止する' do
     poller = build_poller
 
     poller.start
@@ -57,7 +57,7 @@ describe CopyTunerClient::Poller do
     expect(cache['test.key']).to be_nil
   end
 
-  it 'stops polling with an invalid api key' do
+  it '無効な API キーの場合はポーリングを停止する' do
     failure = 'server is napping'
     logger = FakeLogger.new
 
@@ -76,7 +76,7 @@ describe CopyTunerClient::Poller do
     expect(cache['test.key']).to be_nil
   end
 
-  it "logs an error if the background thread can't start" do
+  it 'バックグラウンドスレッドを起動できない場合はエラーをログに残す' do
     allow(Thread).to receive(:new).and_return(nil)
     logger = FakeLogger.new
 
@@ -85,7 +85,7 @@ describe CopyTunerClient::Poller do
     expect(logger).to have_entry(:error, "Couldn't start poller thread")
   end
 
-  it 'flushes the log when polling' do
+  it 'ポーリング時にログを flush する' do
     logger = FakeLogger.new
     allow(logger).to receive(:flush)
 
@@ -94,5 +94,76 @@ describe CopyTunerClient::Poller do
     wait_for_next_sync
 
     expect(logger).to have_received(:flush).at_least(:once)
+  end
+
+  describe 'fork をまたいだ場合' do
+    # Thread.new を実行させると poller スレッドが後始末されずテストを跨いで残るため、
+    # 分岐ロジックだけを見るためにダミーを返す
+    let(:dummy_thread) { instance_double(Thread, join: nil) }
+
+    before do
+      allow(Thread).to receive(:new).and_return(dummy_thread)
+    end
+
+    it '別プロセスで start するとスレッドを張り直す' do
+      poller = build_poller
+
+      allow(Process).to receive(:pid).and_return(100)
+      poller.start
+
+      allow(Process).to receive(:pid).and_return(200)
+      poller.start
+
+      expect(Thread).to have_received(:new).twice
+    end
+
+    it '同じプロセスで二度 start してもスレッドは 1 本だけ' do
+      poller = build_poller
+
+      allow(Process).to receive(:pid).and_return(100)
+      poller.start
+      poller.start
+
+      expect(Thread).to have_received(:new).once
+    end
+  end
+
+  describe 'fork をまたいだ stop' do
+    it '別プロセスで stop してもキューに :stop を残さないので次の start でポーリングが動く' do
+      poller = build_poller
+
+      # 親プロセス側の start ではスレッドを実際に動かさない（fork 後の子には引き継がれないため）
+      allow(Thread).to receive(:new).and_return(instance_double(Thread, join: nil))
+      allow(Process).to receive(:pid).and_return(100)
+      poller.start
+
+      # fork 後の子プロセスで stop → start する流れを再現する
+      allow(Thread).to receive(:new).and_call_original
+      allow(Process).to receive(:pid).and_call_original
+      poller.stop
+      poller.start
+
+      # 1 周目の sync だけでは「:stop がキューに残っている」状態と区別できないため、
+      # 2 周目以降も同期が続くことを確かめる
+      wait_for_next_sync
+      client['test.key'] = 'value'
+      wait_for_next_sync
+
+      expect(cache['test.key']).to eq('value')
+    end
+
+    it '別プロセスの stop では他プロセスのスレッドを join しない' do
+      poller = build_poller
+
+      other_thread = instance_double(Thread, join: nil)
+      allow(Thread).to receive(:new).and_return(other_thread)
+      allow(Process).to receive(:pid).and_return(100)
+      poller.start
+
+      allow(Process).to receive(:pid).and_return(200)
+      poller.stop
+
+      expect(other_thread).not_to have_received(:join)
+    end
   end
 end

--- a/spec/copy_tuner_client/process_guard_spec.rb
+++ b/spec/copy_tuner_client/process_guard_spec.rb
@@ -20,14 +20,14 @@ describe CopyTunerClient::ProcessGuard do
     process_guard
   end
 
-  it 'starts polling from a worker process' do
+  it 'worker プロセスから poller を起動する' do
     process_guard = build_process_guard
     process_guard.start
 
     expect(poller).to have_received(:start)
   end
 
-  it 'registers passenger hooks from the passenger master' do
+  it 'passenger のマスタープロセスから passenger フックを登録する' do
     logger = FakeLogger.new
     passenger = define_constant('PhusionPassenger', FakePassenger.new)
     passenger.become_master
@@ -39,7 +39,7 @@ describe CopyTunerClient::ProcessGuard do
     expect(logger).to have_entry(:info, 'Registered Phusion Passenger fork hook')
   end
 
-  it 'starts polling from a passenger worker' do
+  it 'passenger の worker から poller を起動する' do
     logger = FakeLogger.new
     passenger = define_constant('PhusionPassenger', FakePassenger.new)
     passenger.become_master
@@ -51,7 +51,7 @@ describe CopyTunerClient::ProcessGuard do
     expect(poller).to have_received(:start)
   end
 
-  it 'registers unicorn hooks from the unicorn master' do
+  it 'unicorn のマスタープロセスから unicorn フックを登録する' do
     logger = FakeLogger.new
     define_constant('Unicorn', Module.new)
     http_server = Class.new(FakeUnicornServer)
@@ -65,7 +65,7 @@ describe CopyTunerClient::ProcessGuard do
     expect(logger).to have_entry(:info, 'Registered Unicorn fork hook')
   end
 
-  it 'starts polling from a unicorn worker' do
+  it 'unicorn の worker から poller を起動する' do
     logger = FakeLogger.new
     define_constant('Unicorn', Module.new)
     http_server = Class.new(FakeUnicornServer)
@@ -79,7 +79,121 @@ describe CopyTunerClient::ProcessGuard do
     expect(poller).to have_received(:start)
   end
 
-  it 'flushes when the process terminates' do
+  it 'Puma が読み込まれていても delayed_job のプロセスでは delayed_job フックを登録する' do
+    define_constant('Puma', Module.new)
+    define_constant('Delayed', Module.new)
+    define_constant('Delayed::Worker', Class.new(FakeDelayedWorker))
+    $0 = 'delayed_job'
+    logger = FakeLogger.new
+
+    build_process_guard(logger:).start
+
+    expect(logger).to have_entry(:info, 'Registered Delayed::Job start hook')
+  end
+
+  describe 'Puma' do
+    # PumaStartServerHook はインスタンスを捕捉できないため CopyTunerClient.poller を参照する
+    before do
+      allow(CopyTunerClient).to receive(:poller).and_return(poller)
+    end
+
+    def define_puma_runner
+      define_constant('Puma', Module.new)
+      define_constant('Puma::Runner', Class.new(FakePumaRunner))
+    end
+
+    context 'Puma::Runner が既に定義されているとき' do
+      it 'start_server で poller が起動するフックを仕掛ける' do
+        runner_class = define_puma_runner
+        process_guard = build_process_guard
+        process_guard.start
+
+        runner_class.new.start_server
+
+        # master プロセス側の start と start_server 側の start で 2 回
+        expect(poller).to have_received(:start).twice
+      end
+
+      it 'master プロセスでも poller を起動する' do
+        define_puma_runner
+        process_guard = build_process_guard
+        process_guard.start
+
+        expect(poller).to have_received(:start)
+      end
+
+      it 'フックを登録したことをログに残す' do
+        define_puma_runner
+        logger = FakeLogger.new
+        build_process_guard(logger:).start
+
+        expect(logger).to have_entry(:info, 'Registered Puma fork hook')
+      end
+
+      it '二度 start してもフックは重複せず start_server 1 回で poller の起動も 1 回' do
+        runner_class = define_puma_runner
+        build_process_guard.start
+        build_process_guard.start
+        runner = runner_class.new
+
+        # master プロセス側の start を数に含めないよう、ここで記録をリセットする
+        RSpec::Mocks.space.proxy_for(poller).reset
+        allow(poller).to receive(:start)
+
+        runner.start_server
+
+        expect(poller).to have_received(:start).once
+      end
+    end
+
+    context 'Puma::Runner が未定義のとき' do
+      it 'require して定義されたクラスにフックを仕掛ける' do
+        define_constant('Puma', Module.new)
+        runner_class = Class.new(FakePumaRunner)
+        process_guard = build_process_guard
+
+        allow(process_guard).to receive(:require) do |name|
+          define_constant('Puma::Runner', runner_class) if name == 'puma/launcher'
+          true
+        end
+
+        process_guard.start
+
+        expect(process_guard).to have_received(:require).with('puma')
+        expect(process_guard).to have_received(:require).with('puma/launcher')
+
+        runner_class.new.start_server
+
+        expect(poller).to have_received(:start).twice
+      end
+    end
+
+    context 'require に失敗したとき' do
+      it '例外を投げずに poller を起動し警告を残す' do
+        define_constant('Puma', Module.new)
+        logger = FakeLogger.new
+        process_guard = build_process_guard(logger:)
+        allow(process_guard).to receive(:require).and_raise(LoadError, 'cannot load such file -- puma')
+
+        expect { process_guard.start }.not_to raise_error
+
+        expect(poller).to have_received(:start)
+        expect(logger).to have_entry(:warn, 'Could not load Puma::Runner')
+      end
+
+      it 'NameError でも例外を投げない' do
+        define_constant('Puma', Module.new)
+        process_guard = build_process_guard
+        allow(process_guard).to receive(:require).and_raise(NameError, 'uninitialized constant Puma::HAS_NATIVE_IO_WAIT')
+
+        expect { process_guard.start }.not_to raise_error
+
+        expect(poller).to have_received(:start)
+      end
+    end
+  end
+
+  it 'プロセス終了時に flush する' do
     cache = WritingCache.new
     FileUtils.rm_f(File.join(PROJECT_ROOT, 'tmp', 'written_cache'))
     fork do

--- a/spec/support/fake_delayed_worker.rb
+++ b/spec/support/fake_delayed_worker.rb
@@ -1,0 +1,3 @@
+class FakeDelayedWorker
+  def start; end
+end

--- a/spec/support/fake_puma.rb
+++ b/spec/support/fake_puma.rb
@@ -1,0 +1,3 @@
+class FakePumaRunner
+  def start_server; end
+end


### PR DESCRIPTION
## Summary
- Puma cluster モードで poller スレッドが master プロセスにしか立たず、fork 後の worker に引き継がれずリクエストを処理するプロセスで翻訳が更新されなくなっていた不具合を修正
- ProcessGuard の Puma 検出を `$PROGRAM_NAME` 依存から `defined?(Puma)` ベースに変更し、`Puma::Runner` が未定義でも `puma/launcher` を前倒しで require してから `Puma::Runner#start_server` に prepend するようにした（名前付き定数モジュールで prepend の重複登録を防止）
- `puma?` を spawner 判定チェーンの最後に配置し、delayed_job / good_job など他プロセスのフック登録を奪わないようにした
- Poller の start/stop に pid ガードを追加し、fork を越えた場合に死んだ Thread を張り直し、stop が他プロセスのスレッドに影響しないようにした

## Test plan
- [x] `bundle exec rspec`（全て green）
- [x] `bundle exec rubocop`（no offenses）
- [x] `BUNDLE_GEMFILE=gemfiles/8.0.gemfile bundle exec rspec`
- [x] `BUNDLE_GEMFILE=gemfiles/8.1.gemfile bundle exec rspec`