### PR TITLE
[review] fix: Puma cluster モードで poller が worker に引き継がれない不具合を fork 安全な設計で直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,15 @@ Rails 統合は engine.rb のイニシャライザ経由（ヘルパー/SimpleFo
   （vite.config.ts が `src/main.ts` → `app/assets/javascripts/copytuner.js` を出力）。
 - `local_first_key_regexp` — locale を除いたキー対象・lookup 時に作用（ローカル YAML 優先）。
   local_first キーのアップロード抑止は `Cache#[]=` に集約されている。
+- **poller スレッドの fork 対応は `ForkHook`（`Process._fork` に prepend）に集約する**
+  （fork の直前に `Poller#stop` で協調的に停止し、fork 後に親子の両方で張り直す。理由: fork 後の子に残る
+  Thread オブジェクトの見え方（`alive?` / `join` の結果）はドキュメント化されていない CRuby の実装依存なので、
+  pid を記録して差分を見るような後始末には寄せない。子でも張り直すので、Puma の `fork_worker` のように
+  worker が worker を fork する構成でもサーバ固有のフックなしで poller が立つ。
+  アプリケーションサーバごとのフック（`ProcessGuard#register_*_hook`）を増やす前にここで足りるか確認する）。
+- **`Poller#poll` は例外をスレッドの外へ漏らさない**
+  （`Poller#stop` は fork 経路から呼ばれ、`Thread#join` はスレッドの例外を再送出するため、漏らすと
+  poller の失敗がアプリ側の `fork` を壊す）。
 - **アップロード抑止の新ルールは `Cache#[]=` に足す。`I18nBackend` の書き込み経路（`lookup` / `default` / `store_item`）ごとに個別ガードを足さない**
   （理由: cache への書き込みは全経路が最終的に `Cache#[]=` を通る単一の関門。経路ごとにガードを足すと付け忘れの穴が生まれ、同じチェックが分散して保守負担になる。実際 local_first の抑止は当初 `default` 個別に足したが穴が残り、`Cache#[]=` への集約に作り直した）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Rails 統合は engine.rb のイニシャライザ経由（ヘルパー/SimpleFo
   pid を記録して差分を見るような後始末には寄せない。子でも張り直すので、Puma の `fork_worker` のように
   worker が worker を fork する構成でもサーバ固有のフックなしで poller が立つ。
   アプリケーションサーバごとのフック（`ProcessGuard#register_*_hook`）を増やす前にここで足りるか確認する）。
+  起動方法・モードごとにどのプロセスで poller が起動するかは `docs/poller-startup.md` に実測結果がある。
 - **`Poller#poll` は例外をスレッドの外へ漏らさない**
   （`Poller#stop` は fork 経路から呼ばれ、`Thread#join` はスレッドの例外を再送出するため、漏らすと
   poller の失敗がアプリ側の `fork` を壊す）。

--- a/docs/poller-startup.md
+++ b/docs/poller-startup.md
@@ -1,0 +1,91 @@
+# poller がどのプロセスで起動するか
+
+`Poller` はバックグラウンドスレッドで CopyTuner サーバと同期する。**リクエストを処理するプロセスで
+このスレッドが動いていないと翻訳が更新されない**が、動いていなくてもエラーにはならず、翻訳が古いまま
+になるだけなので気づきにくい。アプリケーションサーバの起動方法とモードによって「どのプロセスがアプリを
+ロードするか」が変わるため、ここに実測結果を残す。
+
+Puma 以外（Unicorn / Passenger / delayed_job / good_job）については `ProcessGuard` のフック登録
+メソッドを参照。
+
+## 前提: アプリをロードしたプロセスで initializer が走る
+
+`CopyTunerClient.configure`（＝ `Configuration#apply` ＝ `ProcessGuard#start`）は、Rails の
+initializer として **アプリをロードしたプロセスで 1 回だけ**走る。したがって「どのプロセスがアプリを
+ロードするか」が起点になる。
+
+## 実測結果
+
+検証環境: puma 8.0.2 / Rails 8.1.3.1 / Ruby 4.0.2（2026-09-03 実測）
+
+| 起動方法 | モード | アプリをロードするプロセス | poller の起動経路 | master に poller |
+| --- | --- | --- | --- | --- |
+| `rails server` | single | そのプロセス | 非 spawner 経路（`start_polling`） | （単一プロセス） |
+| `rails server` | cluster（preload の有無を問わず） | **master のみ** | master で `start_polling` → `ForkHook` が fork 後に worker で張り直す | 立つ |
+| `puma -C` | single | そのプロセス（`Runner#load_and_bind`） | `Puma::Runner#start_server` への prepend | （単一プロセス） |
+| `puma -C` | cluster + preload | master のみ | 各 worker の `start_server` で prepend したフックが発火 | 立たない |
+| `puma -C` | cluster + preload なし | **各 worker** | `$0` の `'cluster worker'` 判定による分岐 | 立たない（master はアプリをロードしない） |
+
+### 判定に使っている値
+
+`ProcessGuard#puma_spawner?` は `defined?(Puma::Runner) && $PROGRAM_NAME.include?('puma')` で判定する。
+実測値は次のとおり。
+
+| 起動方法 | `$PROGRAM_NAME` | `defined?(Puma)` | `defined?(Puma::Runner)` | `puma_spawner?` |
+| --- | --- | --- | --- | --- |
+| `rails server` | `"bin/rails"` | yes | **no** | false |
+| `puma -C`（master / single） | `".../bin/puma"` | yes | yes | true |
+| `puma -C`（preload なしの worker） | `"puma: cluster worker 0: <master pid> [app]"` | yes | yes | true |
+
+`$PROGRAM_NAME` が master と worker で違うのは Puma 側の実装差による。master は
+`launcher.rb` の `Process.setproctitle`（`$0` を変えない）、worker は `cluster/worker.rb` の
+`$0 = title`（変える）を使っている。
+
+## 各行の背景
+
+### `rails server` は preload 設定に関係なく master でアプリをロードする
+
+Rails は Puma を起動する**前に** Rack アプリを組み立てて（`Rails::Server#log_to_stdout` →
+`wrapped_app`）、オブジェクトとして Puma に渡す。そのため `preload_app!` を明示的に切っても worker が
+アプリをロードし直すことはなく、必ず master でロードされる。
+
+この構成では `Puma::Runner` が initializer の時点でまだ未定義なので `puma_spawner?` は false になり、
+master で poller が起動する。fork 後の worker には `ForkHook`（`Process._fork` に prepend）が
+引き継ぐ。master にも poller が 1 本残るが、`puma_spawner?` を無理に真にしようとすると起動方法ごとの
+判定を増やすことになるため、余分な 1 本を許容している。
+
+### Puma 8 は `workers > 1` のとき preload が既定で有効
+
+`Puma::Configuration#set_conditional_default_options` が `preload_app` の既定値を
+`!prune_bundler && workers > 1 && Puma.forkable?` で決めている。非 preload を試すには
+`preload_app!(false)` を明示する必要がある。
+
+### 非 preload では `start_server` の中でアプリがロードされる
+
+`Runner#start_server` は `Puma::Server.new(app, ...)` を呼び、`Runner#app` が
+`@app ||= @config.app` で遅延ロードする。つまり非 preload の worker では、initializer が走る時点で
+既に `start_server` が実行中であり、**そこで `Puma::Runner` に prepend しても間に合わない**。
+
+このため `$0` の `'cluster worker'` 判定は最適化ではなく、この構成で poller を起動する唯一の経路になっている。
+
+## 再検証のしかた
+
+Puma や Rails を上げたときにこの表が変わっていないか確かめるには、次の観測点を見るのが早い。
+
+1. 最小の Rails アプリを用意し、`config/initializers` で `Process.pid` / `Process.ppid` /
+   `$PROGRAM_NAME` / `defined?(Puma::Runner)` を出力する。これで**どのプロセスがアプリをロードしたか**が分かる
+2. 任意のエンドポイントで `CopyTunerClient.poller` の `@thread` を覗き、`alive?` を返す。
+   fork 後の worker が親から継承した dead な Thread を持っていると、ここが `false` になる
+3. 翻訳を返すだけの偽 CopyTuner サーバを立て（`draft_blurbs.json` を返し、`draft_blurbs` /
+   `deploys` の POST を受ける）、`polling_delay` を数秒にする。起動後にサーバ側の翻訳を書き換え、
+   worker が拾うかどうかで実際の同期を確認する
+4. 上の表の 5 構成（`rails server` / `puma -C` × single / cluster+preload / cluster+非 preload）で回す
+
+`ProcessGuard` のログ（`Register Puma fork hook` / `Puma would be clustered mode without preload_app` /
+`start poller thread`）をプロセス ID 付きで集計すると、どの経路を通ったかが分かる。
+
+## 関連
+
+- `CopyTunerClient::ForkHook` — fork をまたいで poller を引き継ぐ。判定が外れて master で poller が
+  起動してしまった場合の安全網でもある
+- [Ruby における fork と Thread の挙動の調査](https://gist.github.com/shunichi/c236b6a85a46a16c60262047ca299608)

--- a/docs/poller-startup.md
+++ b/docs/poller-startup.md
@@ -68,6 +68,20 @@ master で poller が起動する。fork 後の worker には `ForkHook`（`Proc
 
 このため `$0` の `'cluster worker'` 判定は最適化ではなく、この構成で poller を起動する唯一の経路になっている。
 
+## 表のとおりにならない例外
+
+上の表は「poller のスレッドが起動する経路」であって、起動した poller が動き続けることまでは
+保証しない。`Poller` はスレッドの生死とは別にライフサイクルの意図を持っており、次の場合は
+表の経路を通っても poller が居なくなる。
+
+- **`InvalidApiKey`** — API キーが不正だと `poll` が自ら終了し、以後は fork をまたいでも張り直さない
+  （張り直しても同じ理由で死ぬだけなので）。ログに `Invalid API key` が出る
+- **起動時に CopyTuner サーバへ到達できない** — `Configuration#apply` の `cache.download` が
+  `ConnectionError` を再送出するため、そもそもプロセスが起動に失敗する。Puma の worker では
+  `! Unable to start worker` になる
+
+再検証の際は、まずこの 2 つに当たっていないかをログで確かめる。
+
 ## 再検証のしかた
 
 Puma や Rails を上げたときにこの表が変わっていないか確かめるには、次の観測点を見るのが早い。
@@ -88,4 +102,7 @@ Puma や Rails を上げたときにこの表が変わっていないか確か�
 
 - `CopyTunerClient::ForkHook` — fork をまたいで poller を引き継ぐ。判定が外れて master で poller が
   起動してしまった場合の安全網でもある
+- `CopyTunerClient::Poller` — スレッドの生死とは別に `@running`（ポーリングを継続する意図）と
+  `@aborted`（張り直しても同じ理由で死ぬ終わり方をしたか）を持つ。`ForkHook` が fork 後に張り直すか
+  どうかは `Poller#stop` の戻り値、すなわちこの意図で決まる（スレッドが生きているかではない）
 - [Ruby における fork と Thread の挙動の調査](https://gist.github.com/shunichi/c236b6a85a46a16c60262047ca299608)

--- a/lib/copy_tuner_client/fork_hook.rb
+++ b/lib/copy_tuner_client/fork_hook.rb
@@ -9,21 +9,39 @@ module CopyTunerClient
     end
 
     def _fork
-      poller = CopyTunerClient.poller
+      # fork はアプリの任意のタイミングで起きる。Process._fork への prepend は外せないので、
+      # configure 前や configuration 差し替え中に NoMethodError でアプリの fork を
+      # 壊さないよう nil を許容する
+      poller = CopyTunerClient.configuration&.poller
       # スレッドは子プロセスに引き継がれない。fork 後に子へ残る Thread オブジェクトの見え方
       # （alive? / join の結果）はドキュメント化されていない CRuby の実装依存なので、
-      # そこに依存した後始末はせず、fork 前に協調的に停止しておく
+      # そこに依存した後始末はせず、fork 前に協調的に停止しておく。
+      # ここは rescue しない。停止の失敗を握り潰すと、動いている poller ごと fork することになり
+      # このフックの目的そのものを裏切る
       restart = poller ? poller.stop : false
 
       begin
         super
       ensure
-        # ensure は親（super の戻り値 = 子の pid）と子（同 0）の両方を通る。
-        # 「fork 前に動いていたプロセスは fork 後も動いている」状態を双方で復元する。
+        # ensure は親（super の戻り値 = 子の pid）と子（同 0）の両方を通り、super が失敗した
+        # ときも親で復元する。「fork 前に動いていたプロセスは fork 後も動いている」状態を保つ。
         # 子でも張り直すのは、Puma の fork_worker のように worker が worker を fork する
         # 構成でもサーバ固有のフックに頼らず poller を立てるため
-        poller.start if restart
+        ForkHook.restart_poller(poller) if restart
       end
+    end
+
+    # Process.singleton_class に prepend されるため、インスタンスメソッドとして定義すると
+    # Process 自身にメソッドが生えてしまう。フックの補助はモジュール側の特異メソッドに置く
+    #
+    # fork 後に例外を漏らすと「子プロセスは生成済みなのに親の fork が例外を投げる」状態になり、
+    # 呼び出し側が子の pid を受け取れなくなる。起動の失敗はログに落として fork は成立させる
+    def self.restart_poller(poller)
+      poller.start
+    rescue StandardError => e
+      CopyTunerClient.configuration&.logger&.error(
+        "CopyTuner: fork 後の poller 起動に失敗しました: #{e.class}: #{e.message}"
+      )
     end
   end
 end

--- a/lib/copy_tuner_client/fork_hook.rb
+++ b/lib/copy_tuner_client/fork_hook.rb
@@ -39,9 +39,15 @@ module CopyTunerClient
     def self.restart_poller(poller)
       poller.start
     rescue StandardError => e
-      CopyTunerClient.configuration&.logger&.error(
-        "CopyTuner: fork 後の poller 起動に失敗しました: #{e.class}: #{e.message}"
-      )
+      log_error("CopyTuner: fork 後の poller 起動に失敗しました: #{e.class}: #{e.message}")
+    end
+
+    # ログ出力自体が失敗しても fork は成立させる。ここで例外を漏らすと、失敗を握るために
+    # 置いた rescue が逆に fork を壊す
+    def self.log_error(message)
+      CopyTunerClient.configuration&.logger&.error(message)
+    rescue StandardError
+      nil
     end
   end
 end

--- a/lib/copy_tuner_client/fork_hook.rb
+++ b/lib/copy_tuner_client/fork_hook.rb
@@ -1,0 +1,29 @@
+module CopyTunerClient
+  # fork をまたいで poller スレッドを引き継ぐためのフック。
+  # Process._fork に prepend し、fork の直前に poller を協調的に停止して、
+  # fork のあと親子それぞれで張り直す。
+  module ForkHook
+    # Module#prepend は同じモジュールを二重に挿さないので、呼び出し側で登録済みかを見なくてよい
+    def self.install
+      ::Process.singleton_class.prepend(self)
+    end
+
+    def _fork
+      poller = CopyTunerClient.poller
+      # スレッドは子プロセスに引き継がれない。fork 後に子へ残る Thread オブジェクトの見え方
+      # （alive? / join の結果）はドキュメント化されていない CRuby の実装依存なので、
+      # そこに依存した後始末はせず、fork 前に協調的に停止しておく
+      restart = poller ? poller.stop : false
+
+      begin
+        super
+      ensure
+        # ensure は親（super の戻り値 = 子の pid）と子（同 0）の両方を通る。
+        # 「fork 前に動いていたプロセスは fork 後も動いている」状態を双方で復元する。
+        # 子でも張り直すのは、Puma の fork_worker のように worker が worker を fork する
+        # 構成でもサーバ固有のフックに頼らず poller を立てるため
+        poller.start if restart
+      end
+    end
+  end
+end

--- a/lib/copy_tuner_client/poller.rb
+++ b/lib/copy_tuner_client/poller.rb
@@ -9,12 +9,13 @@ module CopyTunerClient
     # @option options [Logger] :logger where errors should be logged
     # @option options [Fixnum] :polling_delay how long to wait in between requests
     def initialize(cache, options)
-      @cache         = cache
-      @polling_delay = options[:polling_delay]
-      @logger        = options[:logger]
-      @command_queue = CopyTunerClient::QueueWithTimeout.new
-      @mutex         = Mutex.new
-      @thread        = nil
+      @cache          = cache
+      @polling_delay  = options[:polling_delay]
+      @logger         = options[:logger]
+      @command_queue  = CopyTunerClient::QueueWithTimeout.new
+      @mutex          = Mutex.new
+      @thread         = nil
+      @last_synced_at = nil
     end
 
     def start
@@ -26,11 +27,17 @@ module CopyTunerClient
       end
     end
 
+    # @return [Boolean] 動いていたスレッドを停止したなら +true+
     def stop
       @mutex.synchronize do
+        # 積んだ :stop は pop されるまでキューに残るため、止める相手のスレッドがあるときだけ積む。
+        # さもないと次に start したスレッドが 1 周目でそれを pop して自分を止めてしまう
+        next false if @thread.nil?
+
         @command_queue.uniq_push(:stop)
-        @thread&.join
+        @thread.join
         @thread = nil
+        true
       end
     end
 
@@ -47,19 +54,46 @@ module CopyTunerClient
     attr_reader :cache, :logger, :polling_delay
 
     def poll
-      loop do
-        cache.sync
-        logger.flush if logger.respond_to?(:flush)
-        begin
-          command = @command_queue.pop_with_timeout(polling_delay)
-          break if command == :stop
-        rescue ThreadError
-          # timeout
-        end
+      timeout = remaining_delay
+      until wait_for_command(timeout) == :stop
+        sync
+        timeout = polling_delay
       end
-      @logger.info 'stop poller thread'
+      logger.info 'stop poller thread'
     rescue InvalidApiKey => e
       logger.error(e.message)
+    rescue StandardError => e
+      # 例外はスレッドの外へ漏らさない。stop の join は fork の直前にも呼ばれるため、
+      # 漏らすと poller の失敗がアプリ側の fork まで巻き添えにする
+      logger.error("poller thread aborted: #{e.class}: #{e.message}")
+    end
+
+    def sync
+      cache.sync
+      @last_synced_at = monotonic_now
+      logger.flush if logger.respond_to?(:flush)
+    end
+
+    # 最初の待ち時間を「前回 sync からの残り」にすることで、stop / start を繰り返しても
+    # sync の間隔を保つ。fork のたびに stop / start されるので、これが無いと worker を
+    # fork する数だけ親プロセスで sync（HTTP 往復）が走り直し、その分 join も待たされる。
+    # 基点には NTP や手動の時刻変更で巻き戻らない CLOCK_MONOTONIC を使う
+    # （Time.now だと時計が後ろに飛んだぶんだけ待ち時間が伸びて同期が止まる）
+    def remaining_delay
+      return 0 if @last_synced_at.nil?
+
+      remaining = polling_delay - (monotonic_now - @last_synced_at)
+      remaining.negative? ? 0 : remaining
+    end
+
+    def wait_for_command(timeout)
+      @command_queue.pop_with_timeout(timeout)
+    rescue ThreadError
+      nil # timeout
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/copy_tuner_client/poller.rb
+++ b/lib/copy_tuner_client/poller.rb
@@ -20,23 +20,31 @@ module CopyTunerClient
 
     def start
       @mutex.synchronize do
-        if @thread.nil?
-          @logger.info 'start poller thread'
-          @thread = Thread.new { poll } or logger.error("Couldn't start poller thread")
-        end
+        # fork 後の子は親から dead な Thread オブジェクトを継承するため、nil かどうかだけでは
+        # 「動いていない」を判定できない。死んでいるスレッドは張り直す
+        next if @thread&.alive?
+
+        # コマンドキューは世代ごとに作り直し、スレッドに自分のキューを渡す。前の世代宛に
+        # 積まれたまま未消費で残った :stop を次の世代が 1 周目で拾って自殺するのを、
+        # 「1 つのキューは 1 本のスレッドだけのもの」という不変条件で構造的に防ぐ
+        queue = CopyTunerClient::QueueWithTimeout.new
+        @command_queue = queue
+        @logger.info 'start poller thread'
+        @thread = Thread.new { poll(queue) } or logger.error("Couldn't start poller thread")
       end
     end
 
     # @return [Boolean] 動いていたスレッドを停止したなら +true+
     def stop
       @mutex.synchronize do
-        # 積んだ :stop は pop されるまでキューに残るため、止める相手のスレッドがあるときだけ積む。
-        # さもないと次に start したスレッドが 1 周目でそれを pop して自分を止めてしまう
-        next false if @thread.nil?
+        thread = @thread
+        @thread = nil
+        # 例外で終わったスレッドは非 nil のまま dead で残る。それに :stop を積んでも誰も
+        # pop しない。ここで false を返すことが ForkHook の「元々動いていたか」の判断に効く
+        next false unless thread&.alive?
 
         @command_queue.uniq_push(:stop)
-        @thread.join
-        @thread = nil
+        thread.join
         true
       end
     end
@@ -53,9 +61,9 @@ module CopyTunerClient
 
     attr_reader :cache, :logger, :polling_delay
 
-    def poll
+    def poll(queue)
       timeout = remaining_delay
-      until wait_for_command(timeout) == :stop
+      until wait_for_command(queue, timeout) == :stop
         sync
         timeout = polling_delay
       end
@@ -64,8 +72,9 @@ module CopyTunerClient
       logger.error(e.message)
     rescue StandardError => e
       # 例外はスレッドの外へ漏らさない。stop の join は fork の直前にも呼ばれるため、
-      # 漏らすと poller の失敗がアプリ側の fork まで巻き添えにする
-      logger.error("poller thread aborted: #{e.class}: #{e.message}")
+      # 漏らすと poller の失敗がアプリ側の fork まで巻き添えにする。
+      # ここで握ると report_on_exception による stderr 出力も消えるので backtrace を残す
+      logger.error("poller thread aborted: #{e.class}: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
     end
 
     def sync
@@ -86,8 +95,10 @@ module CopyTunerClient
       remaining.negative? ? 0 : remaining
     end
 
-    def wait_for_command(timeout)
-      @command_queue.pop_with_timeout(timeout)
+    # 自分の世代のキューを受け取る。@command_queue は start のたびに差し替わるため、
+    # 終了処理中の古いスレッドが新しい世代のキューを覗いてしまわないようにする
+    def wait_for_command(queue, timeout)
+      queue.pop_with_timeout(timeout)
     rescue ThreadError
       nil # timeout
     end

--- a/lib/copy_tuner_client/poller.rb
+++ b/lib/copy_tuner_client/poller.rb
@@ -16,10 +16,19 @@ module CopyTunerClient
       @mutex          = Mutex.new
       @thread         = nil
       @last_synced_at = nil
+      # スレッドの生死とは別に、ライフサイクルの意図を持つ。
+      # @running: ポーリングを継続する意図があるか（start で true / stop で false）
+      # @aborted: 張り直しても同じ理由で死ぬと分かっている終わり方をしたか
+      @running        = false
+      @aborted        = false
     end
 
     def start
       @mutex.synchronize do
+        @running = true
+        # 回復の見込みがない理由で終了しているなら張り直さない。fork のたびに同じ例外で
+        # 死ぬスレッドを作り直してログを埋めるだけになる
+        next if @aborted
         # fork 後の子は親から dead な Thread オブジェクトを継承するため、nil かどうかだけでは
         # 「動いていない」を判定できない。死んでいるスレッドは張り直す
         next if @thread&.alive?
@@ -34,18 +43,26 @@ module CopyTunerClient
       end
     end
 
-    # @return [Boolean] 動いていたスレッドを停止したなら +true+
+    # 戻り値は ForkHook が「fork 後に張り直すか」を決めるのに使う。スレッドの生死ではなく
+    # ポーリングを継続する意図があったかを返す。想定外の例外で死んだだけのスレッドは
+    # fork 後に張り直したいが、生死で判定すると張り直せなくなる
+    #
+    # @return [Boolean] ポーリング継続の意図があった（＝ fork 後に張り直すべき）なら +true+
     def stop
       @mutex.synchronize do
+        resumable = @running && !@aborted
+        @running = false
+
         thread = @thread
         @thread = nil
         # 例外で終わったスレッドは非 nil のまま dead で残る。それに :stop を積んでも誰も
-        # pop しない。ここで false を返すことが ForkHook の「元々動いていたか」の判断に効く
-        next false unless thread&.alive?
+        # pop しないので、生きているときだけ積んで待つ
+        if thread&.alive?
+          @command_queue.uniq_push(:stop)
+          thread.join
+        end
 
-        @command_queue.uniq_push(:stop)
-        thread.join
-        true
+        resumable
       end
     end
 
@@ -69,6 +86,8 @@ module CopyTunerClient
       end
       logger.info 'stop poller thread'
     rescue InvalidApiKey => e
+      # キーが不正なら張り直しても同じ結果になるので、以後の再開を止める
+      @aborted = true
       logger.error(e.message)
     rescue StandardError => e
       # 例外はスレッドの外へ漏らさない。stop の join は fork の直前にも呼ばれるため、

--- a/lib/copy_tuner_client/process_guard.rb
+++ b/lib/copy_tuner_client/process_guard.rb
@@ -120,9 +120,12 @@ module CopyTunerClient
       ::Process.singleton_class.prepend(hook_module)
     end
 
+    # 起動方法（rails server / puma -C）とモード（single / cluster / preload の有無）ごとに
+    # どのプロセスで poller が起動するかは docs/poller-startup.md にまとめてある
     def register_puma_hook
-      # If Puma is clustered mode without preload_app, this method is called on worker process.
-      # Just start poller and return.
+      # 非 preload の cluster worker はここに来る。この構成ではアプリのロードが
+      # Puma::Runner#start_server の中で起きるため、今から prepend しても実行中の呼び出しには
+      # 間に合わない。つまりこの分岐が poller を起動する唯一の経路で、最適化ではなく必須
       if $PROGRAM_NAME.include?('cluster worker')
         @logger.info('Puma would be clustered mode without preload_app')
         @poller.start
@@ -130,8 +133,9 @@ module CopyTunerClient
       end
 
       @logger.info('Register Puma fork hook')
-      # If Puma is clustered mode with preload_app, this method is called before fork.
-      # Delay poller start until Puma::Runner#start_server which is called on worker process.
+      # preload ありの cluster ではこのメソッドが fork 前の master で走る。master は
+      # リクエストを捌かないのでここでは起動せず、worker 側で呼ばれる
+      # Puma::Runner#start_server まで遅らせる
       poller = @poller
       hook_module =
         Module.new do

--- a/lib/copy_tuner_client/process_guard.rb
+++ b/lib/copy_tuner_client/process_guard.rb
@@ -1,3 +1,5 @@
+require 'copy_tuner_client/fork_hook'
+
 module CopyTunerClient
   # Starts the poller from a worker process, or register hooks for a spawner
   # process (such as in Unicorn or Passenger). Also registers hooks for exiting
@@ -14,6 +16,9 @@ module CopyTunerClient
 
     # Starts the poller or registers hooks
     def start
+      # fork の前後で poller を張り直すフックは、どのプロセスでも必ず登録する
+      ForkHook.install
+
       if spawner?
         register_spawn_hooks
       else

--- a/lib/copy_tuner_client/queue_with_timeout.rb
+++ b/lib/copy_tuner_client/queue_with_timeout.rb
@@ -51,10 +51,16 @@ module CopyTunerClient
 
     def wait_with_timeout(timeout)
       # wait for element or timeout
-      timeout_time = timeout + Time.now.to_f
-      while @queue.empty? && (remaining_time = timeout_time - Time.now.to_f).positive?
+      # NTP の step 補正や手動の時刻変更で巻き戻らない CLOCK_MONOTONIC で締め切りを測る。
+      # ウォールクロックだと時計が後ろへ飛んだぶんだけ待ち時間が伸びる
+      deadline = monotonic_now + timeout
+      while @queue.empty? && (remaining_time = deadline - monotonic_now).positive?
         @received.wait(@mutex, remaining_time)
       end
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/spec/copy_tuner_client/fork_hook_spec.rb
+++ b/spec/copy_tuner_client/fork_hook_spec.rb
@@ -81,6 +81,14 @@ describe CopyTunerClient::ForkHook do
       expect { Process.waitpid(fork { exit!(0) }) }.not_to raise_error
     end
 
+    it 'ログ出力自体が失敗しても fork は成立する' do
+      allow(poller).to receive(:stop).and_return(true)
+      allow(poller).to receive(:start).and_raise(ThreadError, 'cannot create thread')
+      allow(CopyTunerClient.configuration.logger).to receive(:error).and_raise('logger is broken')
+
+      expect { Process.waitpid(fork { exit!(0) }) }.not_to raise_error
+    end
+
     it 'fork 後の poller 起動に失敗しても fork 自体は成立する' do
       allow(poller).to receive(:stop).and_return(true)
       allow(poller).to receive(:start).and_raise(ThreadError, 'cannot create thread')
@@ -90,6 +98,43 @@ describe CopyTunerClient::ForkHook do
   end
 
   describe '実際に fork したとき' do
+    it 'fork 前に poller が例外で死んでいても親子とも張り直す' do
+      # rails server の cluster では ForkHook が唯一の再開経路なので、ここで張り直さないと
+      # 親子とも poller を失う
+      fail_once = true
+      allow(cache).to receive(:sync).and_wrap_original do |original, *args|
+        if fail_once
+          fail_once = false
+          raise 'boom'
+        end
+        original.call(*args)
+      end
+
+      poller.start
+      sleep(polling_delay * 0.4) # スレッドが例外で終わる
+
+      reader, writer = IO.pipe
+      pid =
+        fork do
+          reader.close
+          client['child.key'] = 'value'
+          sleep(polling_delay * 3)
+          writer.write(cache['child.key'].to_s)
+          writer.close
+          exit!(0)
+        end
+
+      writer.close
+      child_result = reader.read
+      Process.waitpid(pid)
+
+      client['parent.key'] = 'value'
+      sleep(polling_delay * 3)
+
+      expect(child_result).to eq('value')
+      expect(cache['parent.key']).to eq('value')
+    end
+
     it '子プロセスでも poller がポーリングを続ける' do
       poller.start
       reader, writer = IO.pipe

--- a/spec/copy_tuner_client/fork_hook_spec.rb
+++ b/spec/copy_tuner_client/fork_hook_spec.rb
@@ -14,7 +14,8 @@ describe CopyTunerClient::ForkHook do
 
   before do
     described_class.install
-    allow(CopyTunerClient).to receive(:poller).and_return(poller)
+    # フックは CopyTunerClient.configuration&.poller を見るので、実際の設定に載せる
+    CopyTunerClient.configuration.poller = poller
   end
 
   after do
@@ -68,6 +69,23 @@ describe CopyTunerClient::ForkHook do
 
       expect { forkable._fork }.to raise_error(Errno::EAGAIN)
       expect(events).to eq(%i[stop fork start])
+    end
+  end
+
+  describe 'poller を取得できないとき' do
+    it 'configuration が nil でも fork を壊さない' do
+      # Process._fork への prepend は外せないので、ここで例外を漏らすとアプリの
+      # すべての fork が失敗する
+      CopyTunerClient.configuration = nil
+
+      expect { Process.waitpid(fork { exit!(0) }) }.not_to raise_error
+    end
+
+    it 'fork 後の poller 起動に失敗しても fork 自体は成立する' do
+      allow(poller).to receive(:stop).and_return(true)
+      allow(poller).to receive(:start).and_raise(ThreadError, 'cannot create thread')
+
+      expect { Process.waitpid(fork { exit!(0) }) }.not_to raise_error
     end
   end
 

--- a/spec/copy_tuner_client/fork_hook_spec.rb
+++ b/spec/copy_tuner_client/fork_hook_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe CopyTunerClient::ForkHook do
+  let(:client) { FakeClient.new }
+  let(:cache) { CopyTunerClient::Cache.new(client, logger: FakeLogger.new) }
+  let(:poller) do
+    config = CopyTunerClient::Configuration.new.to_hash
+    CopyTunerClient::Poller.new(cache, config.update(logger: FakeLogger.new, polling_delay:))
+  end
+
+  def polling_delay
+    0.5
+  end
+
+  before do
+    described_class.install
+    allow(CopyTunerClient).to receive(:poller).and_return(poller)
+  end
+
+  after do
+    poller.stop
+  end
+
+  describe '停止と再開の順序' do
+    # 実際に fork してしまうと「fork の瞬間にスレッドが止まっているか」を観測できないため、
+    # _fork の代わりに記録だけするオブジェクトに prepend して順序を見る
+    def build_forkable(events, &fork_body)
+      forkable = Object.new
+      forkable.define_singleton_method(:_fork) do
+        events << :fork
+        fork_body ? fork_body.call : 0
+      end
+      forkable.singleton_class.prepend(described_class)
+      forkable
+    end
+
+    def stub_poller(events, stopped:)
+      allow(poller).to receive(:stop) do
+        events << :stop
+        stopped
+      end
+      allow(poller).to receive(:start) { events << :start }
+    end
+
+    it 'fork の前に poller を停止し、fork の後に再開する' do
+      events = []
+      stub_poller(events, stopped: true)
+
+      build_forkable(events)._fork
+
+      expect(events).to eq(%i[stop fork start])
+    end
+
+    it 'fork 前に poller が動いていなければ再開しない' do
+      events = []
+      stub_poller(events, stopped: false)
+
+      build_forkable(events)._fork
+
+      expect(events).to eq(%i[stop fork])
+    end
+
+    it 'fork が失敗しても poller を再開する' do
+      events = []
+      stub_poller(events, stopped: true)
+
+      forkable = build_forkable(events) { raise Errno::EAGAIN }
+
+      expect { forkable._fork }.to raise_error(Errno::EAGAIN)
+      expect(events).to eq(%i[stop fork start])
+    end
+  end
+
+  describe '実際に fork したとき' do
+    it '子プロセスでも poller がポーリングを続ける' do
+      poller.start
+      reader, writer = IO.pipe
+
+      pid =
+        fork do
+          reader.close
+          client['test.key'] = 'value'
+          sleep(polling_delay * 3)
+          writer.write(cache['test.key'].to_s)
+          writer.close
+          exit!(0)
+        end
+
+      writer.close
+      result = reader.read
+      Process.waitpid(pid)
+
+      expect(result).to eq('value')
+    end
+
+    it '親プロセスでも poller がポーリングを続ける' do
+      poller.start
+      sleep(polling_delay * 0.2)
+
+      Process.waitpid(fork { exit!(0) })
+
+      client['test.key'] = 'value'
+      sleep(polling_delay * 3)
+
+      expect(cache['test.key']).to eq('value')
+    end
+  end
+end

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -189,12 +189,24 @@ describe CopyTunerClient::Poller do
       expect(cache['test.key']).to eq('value')
     end
 
-    it 'スレッドが例外で死んだ後の stop は false を返す' do
+    # stop の戻り値は ForkHook の「fork 後に張り直すか」の判断に使われる。スレッドの生死ではなく
+    # 「ポーリングを継続する意図があるか」を返す必要がある
+    it 'スレッドが例外で死んでいても、起動中だったなら stop は true を返す' do
       poller = build_poller
       allow(cache).to receive(:sync).and_raise('boom')
       poller.start
       sleep(polling_delay * 0.3)
 
+      expect(poller.stop).to be true
+    end
+
+    it '回復の見込みがない理由で終了した後の stop は false を返す' do
+      poller = build_poller
+      allow(cache).to receive(:sync).and_raise(CopyTunerClient::InvalidApiKey, 'Invalid API key')
+      poller.start
+      sleep(polling_delay * 0.3)
+
+      # API キーが不正なら fork のたびに張り直しても同じ理由で死ぬだけなので再開させない
       expect(poller.stop).to be false
     end
   end

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -11,7 +11,7 @@ describe CopyTunerClient::Poller do
 
   def build_poller(config = {})
     config[:logger] ||= FakeLogger.new
-    config[:polling_delay] = polling_delay
+    config[:polling_delay] ||= polling_delay
     default_config = CopyTunerClient::Configuration.new.to_hash
     poller = CopyTunerClient::Poller.new(cache, default_config.update(config))
     pollers << poller
@@ -139,30 +139,94 @@ describe CopyTunerClient::Poller do
     end
   end
 
-  describe '再開時の sync 間隔' do
-    it '初回の start では待たずに sync する' do
+  describe '世代をまたいだコマンドの混入' do
+    # :stop は pop されるまでキューに残る。前の世代のスレッド宛に積まれた :stop を
+    # 次の世代のスレッドが拾うと、起動直後に自分を止めてしまう
+    it 'スレッドが例外で死んだ後に stop → start してもポーリングが続く' do
       poller = build_poller
+      allow(cache).to receive(:sync).and_raise('boom')
+      poller.start
+      sleep(polling_delay * 0.3) # スレッドが例外で終わるのを待つ
+
+      allow(cache).to receive(:sync).and_call_original
+      poller.stop
+      poller.start
+
+      wait_for_next_sync
+      client['test.key'] = 'value'
+      wait_for_next_sync
+
+      expect(cache['test.key']).to eq('value')
+    end
+
+    it 'stop の直後に sync が例外で終わっても、次の start でポーリングが続く' do
+      poller = build_poller
+      # stop が :stop を積んだ後にスレッドが例外で終わる順序を作る。
+      # sync に入ったところで stop を待たせ、:stop を積み終えてから例外にする
+      syncing = Queue.new
+      resume = Queue.new
+      allow(cache).to receive(:sync) do
+        syncing << true
+        resume.pop
+        raise 'boom'
+      end
 
       poller.start
-      sleep(polling_delay * 0.2)
+      syncing.pop # スレッドが sync に入った
+
+      stopper = Thread.new { poller.stop }
+      sleep(0.1) # :stop がキューに積まれるのを待つ
+      resume << true # ここで sync が例外になり、:stop は消費されない
+      stopper.join
+
+      allow(cache).to receive(:sync).and_call_original
+      poller.start
+
+      wait_for_next_sync
+      client['test.key'] = 'value'
+      wait_for_next_sync
+
+      expect(cache['test.key']).to eq('value')
+    end
+
+    it 'スレッドが例外で死んだ後の stop は false を返す' do
+      poller = build_poller
+      allow(cache).to receive(:sync).and_raise('boom')
+      poller.start
+      sleep(polling_delay * 0.3)
+
+      expect(poller.stop).to be false
+    end
+  end
+
+  describe '再開時の sync 間隔' do
+    # 経過時間で判定するため、CI の負荷や GC で sleep が伸びても落ちないよう
+    # 他のテストより長い間隔を使ってマージンを稼ぐ
+    let(:slow_delay) { 2.0 }
+
+    it '初回の start では待たずに sync する' do
+      poller = build_poller(polling_delay: slow_delay)
+
+      poller.start
+      sleep(slow_delay * 0.2)
 
       expect(client.downloads).to eq(1)
     end
 
     it '停止直後に再開したときは前回 sync からの残り時間を待ってから sync する' do
-      poller = build_poller
+      poller = build_poller(polling_delay: slow_delay)
       poller.start
-      sleep(polling_delay * 0.2)
+      sleep(slow_delay * 0.2)
       poller.stop
 
       poller.start
 
       # 前回 sync から polling_delay 経つまでは sync しない
-      sleep(polling_delay * 0.4)
+      sleep(slow_delay * 0.4)
       expect(client.downloads).to eq(1)
 
       # 残り時間が過ぎれば sync が再開する
-      sleep(polling_delay * 0.8)
+      sleep(slow_delay * 0.8)
       expect(client.downloads).to eq(2)
     end
   end

--- a/spec/copy_tuner_client/poller_spec.rb
+++ b/spec/copy_tuner_client/poller_spec.rb
@@ -95,4 +95,75 @@ describe CopyTunerClient::Poller do
 
     expect(logger).to have_received(:flush).at_least(:once)
   end
+
+  describe '#stop' do
+    it 'スレッドを停止したときは true を返す' do
+      poller = build_poller
+      poller.start
+
+      expect(poller.stop).to be true
+    end
+
+    it 'スレッドが動いていないときは false を返す' do
+      poller = build_poller
+
+      expect(poller.stop).to be false
+    end
+
+    it 'スレッドが例外で終わっていても例外を再送出しない' do
+      # stop は fork の直前にも呼ばれる。ここで join が poller の例外を再送出すると
+      # アプリ側の fork まで巻き添えになる
+      logger = FakeLogger.new
+      allow(cache).to receive(:sync).and_raise('boom')
+      poller = build_poller(logger:)
+      poller.start
+      sleep(polling_delay * 0.2)
+
+      expect { poller.stop }.not_to raise_error
+      expect(logger).to have_entry(:error, 'boom')
+    end
+
+    it 'start していないときに stop してもキューに :stop を残さない' do
+      poller = build_poller
+      poller.stop
+
+      poller.start
+
+      # 1 周目の sync だけでは「:stop がキューに残っている」状態と区別できないため、
+      # 2 周目以降も同期が続くことを確かめる
+      wait_for_next_sync
+      client['test.key'] = 'value'
+      wait_for_next_sync
+
+      expect(cache['test.key']).to eq('value')
+    end
+  end
+
+  describe '再開時の sync 間隔' do
+    it '初回の start では待たずに sync する' do
+      poller = build_poller
+
+      poller.start
+      sleep(polling_delay * 0.2)
+
+      expect(client.downloads).to eq(1)
+    end
+
+    it '停止直後に再開したときは前回 sync からの残り時間を待ってから sync する' do
+      poller = build_poller
+      poller.start
+      sleep(polling_delay * 0.2)
+      poller.stop
+
+      poller.start
+
+      # 前回 sync から polling_delay 経つまでは sync しない
+      sleep(polling_delay * 0.4)
+      expect(client.downloads).to eq(1)
+
+      # 残り時間が過ぎれば sync が再開する
+      sleep(polling_delay * 0.8)
+      expect(client.downloads).to eq(2)
+    end
+  end
 end

--- a/spec/copy_tuner_client/process_guard_spec.rb
+++ b/spec/copy_tuner_client/process_guard_spec.rb
@@ -20,6 +20,14 @@ describe CopyTunerClient::ProcessGuard do
     process_guard
   end
 
+  it 'fork の前後で poller を張り直すフックを登録する' do
+    allow(CopyTunerClient::ForkHook).to receive(:install)
+
+    build_process_guard.start
+
+    expect(CopyTunerClient::ForkHook).to have_received(:install)
+  end
+
   it 'starts polling from a worker process' do
     process_guard = build_process_guard
     process_guard.start

--- a/spec/copy_tuner_client/queue_with_timeout_spec.rb
+++ b/spec/copy_tuner_client/queue_with_timeout_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'timeout'
+
+describe CopyTunerClient::QueueWithTimeout do
+  subject(:queue) { described_class.new }
+
+  describe '#pop_with_timeout' do
+    it 'キューに要素があれば取り出す' do
+      queue << :sync
+
+      expect(queue.pop_with_timeout(0)).to eq(:sync)
+    end
+
+    it '要素が無いままタイムアウトしたら ThreadError を投げる' do
+      expect { queue.pop_with_timeout(0.1) }.to raise_error(ThreadError)
+    end
+
+    it 'ウォールクロックが巻き戻ってもタイムアウトが伸びない' do
+      # 待っている最中に NTP の step 補正や手動の時刻変更で時計が後ろへ飛ぶ状況を模す。
+      # 経過時間をウォールクロックで測っていると、飛んだ幅がそのまま待ち時間に乗る
+      base = Time.now
+      allow(Time).to receive(:now).and_return(base, base - 3600)
+
+      expect { Timeout.timeout(2) { queue.pop_with_timeout(0.1) } }.to raise_error(ThreadError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,4 +26,10 @@ RSpec.configure do |config|
     FakeCopyTunerApp.reset
     reset_config
   end
+
+  # apply を通す spec は本物の poller スレッドを起動するので、example ごとに止める。
+  # 放置するとスレッドがスイート終了まで積み上がり、実際に HTTP を叩き続ける
+  config.after do
+    CopyTunerClient.configuration&.poller&.stop
+  end
 end


### PR DESCRIPTION
#150 を置き換える PR です。@aki77 の合意のうえで作り直しました。

## 何が壊れていたか

Puma cluster モードで poller スレッドが master にしか立たず、リクエストを処理する worker で翻訳が更新されない。

実測したところ、**`rails server` で起動している Puma cluster は preload 設定に関わらず全滅**でした。Rails は Puma を起動する前に Rack アプリを組み立てて（`Rails::Server#log_to_stdout` → `wrapped_app`）オブジェクトとして Puma に渡すため、`preload_app!` を明示的に切っても initializer は必ず master で走ります。そこで起動した poller スレッドは fork で worker に引き継がれません。

再現時の worker の状態（master から継承した dead な Thread を持っている）:

```
--- 起動直後 ---
  pid=1887532 ppid=1887497 poller_alive=False translation=BEFORE thread=#<Thread:0x...de0 poller.rb:24 dead>
  pid=1887537 ppid=1887497 poller_alive=False translation=BEFORE thread=#<Thread:0x...de0 poller.rb:24 dead>
  (サーバ側の翻訳を AFTER に変更、polling_delay=3s なので 8 秒待つ)
--- 翻訳を変更して 8 秒後 ---
  pid=1887532 poller_alive=False translation=BEFORE   ← 更新されない
  pid=1887537 poller_alive=False translation=BEFORE   ← 更新されない
```

## 直し方

サーバごとの判定を強化するのではなく、`Process._fork` に prepend する `ForkHook` に寄せました。fork の直前に協調的に stop し、fork の後に**親子の両方で**張り直します。

fork 後の子に残る Thread オブジェクトの見え方（`alive?` / `join` の結果）はドキュメント化されていない CRuby の実装依存なので、pid を記録して差分を見る形の後始末には寄せていません（[調査](https://gist.github.com/shunichi/c236b6a85a46a16c60262047ca299608)）。

子でも張り直すのは、Puma の `fork_worker` のように worker が worker を fork する構成で `Puma::Runner#start_server` が再度呼ばれず poller が恒久停止するのを避けるためです（#150 のレビューで @aki77 が指摘していた点）。

あわせて `Poller` のライフサイクルを整理しました。

- **コマンドキューを世代ごとに作り直す**。積んだ `:stop` は pop されるまで残るため、前の世代のスレッド宛に積まれて未消費のまま残った `:stop` を、次の世代が 1 周目で拾って即死していた。「1 つのキューは 1 本の poller スレッドだけのもの」という不変条件にし、スレッドには自分の世代のキューを引数で渡している
- **`stop` の戻り値はスレッドの生死ではなく「ポーリングを継続する意図があったか」**。この値は `ForkHook` が「fork 後に張り直すか」を決めるのに使う。生死で判定すると、想定外の例外で死んだ poller が fork 後に張り直されない。`@running`（`start` で true / `stop` で false）と `@aborted`（張り直しても同じ理由で死ぬ終わり方をしたか）で管理し、`InvalidApiKey` のような意図的終了は復活させない
- **`start` は dead スレッドを張り直す**。fork 後の子は親から dead な Thread を継承するので、nil かどうかだけでは「動いていない」を判定できない
- **`poll` は例外をスレッドの外へ漏らさない**。`stop` は fork 経路から呼ばれ、`Thread#join` はスレッドの例外を再送出するため、漏らすと poller の失敗がアプリ側の `fork` を壊す。握ると `report_on_exception` の stderr 出力も消えるので backtrace も記録する
- **再開時の最初の待ち時間を「前回 sync からの残り」にした**。worker を N 台 fork すると親プロセスで `stop` の `join` と再 sync が N 回直列に走り、起動が HTTP 往復ぶん遅くなる
- **`ForkHook` は `configuration` が nil でも `fork` を壊さない**。`Process._fork` への prepend は外せないので、ここで例外を漏らすとアプリのすべての `fork` が失敗する。ただし fork 前の `stop` は握り潰さない（動いている poller ごと fork することになり、このフックの目的を裏切るため）。握るのは fork 後の `start` と、そのログ出力だけ

## #150 の Puma 判定変更は持ち込んでいません

`puma` バイナリ起動を含めて全構成を実測した結果、**壊れているのは `rails server` 経由だけ**でした。

| 起動方法 | モード | master（未修正） | 本 PR |
| --- | --- | --- | --- |
| `rails server` | single | OK | OK |
| `rails server` | cluster（preload 有無を問わず） | **NG** | OK |
| `puma -C` | single | OK | OK |
| `puma -C` | cluster + preload | OK | OK |
| `puma -C` | cluster + preload なし | OK | OK |

判定変更を入れない理由:

1. 目的（`rails server` で worker に poller が立たない）は `ForkHook` が起動方法に依存せず解決する
2. 到達する状態が同じ。#150 の `register_puma_hook` は末尾で `start_polling_locally` を無条件に呼ぶので、`rails server` では「master も worker も poller を持つ」になり本 PR と同一
3. `defined?(Puma)` で判定すると rails console / rake など Puma をサーバとして使っていないプロセスも spawner 扱いになり、`puma/launcher` の前倒し require（実測 60〜70ms）が乗る
4. `puma -C` では今 master に poller が立たないが、#150 を入れると `start_polling_locally` により **master にも 1 本増える**（正しく動いている構成の劣化）

## その他

- `spec_helper.rb` に poller スレッドの後始末を追加しました。`CopyTunerClient.configure` を apply 付きで呼ぶ spec が実スレッドを起動していて、スイート全体で **19 本**が終了まで残り HTTP を叩き続けていました（0 本に）
- `QueueWithTimeout` の締め切り計算を `Time.now` から `CLOCK_MONOTONIC` に変えました。時計が後ろへ飛ぶと飛んだ幅ぶん待ち時間が伸びる実バグです（別コミット）
- `docs/poller-startup.md` に、起動方法 × モードごとにどのプロセスで poller が起動するかの実測結果と再検証手順を残しました

## レビュー

Claude と Codex でクロスレビューを 2 巡しました。

**マージ前に直した点**

- **`:stop` の残留で poller が恒久停止する**（2 経路）。Codex は「`stop` が `:stop` を積んだ直後に `cache.sync` が例外で終わる」競合を、Claude は「`stop` を呼ぶ前に既にスレッドが死んでいる」決定的経路を検出。前者は `stop` 側のガードでは防げないため、世代ごとにキューを作り直す形で両方を塞いだ
- **dead スレッドの張り直しが `ForkHook` 経路で効いていなかった**。`stop` が生死で判定していたため `restart` が false になり、`ensure` の `start` がそもそも呼ばれていなかった。`rails server` の cluster では `ForkHook` が唯一の再開経路なので、親子とも poller を失う。ライフサイクルの意図と生死を分離して解消
- `ForkHook` の fail-safe 化、`poll` の backtrace 記録、経過時間に依存するテストのマージン拡大

**見送った点**（別タスクで扱います）

- `ForkHook` の `stop` が `fork` をブロックしうる（進行中の `cache.sync` を待つため、上限 ~10 秒 / アップロード待ちがあれば ~20 秒）。`polling_delay` 既定 300 秒に対し sync は数百 ms なので確率は 0.1% 未満だが、ジョブごとに `fork` する構成ではテールが効く
- `stop` と `super` のあいだの TOCTOU。発生条件が狭く、`start` の呼び出し元が限られるため

## Test plan

- [x] `bundle exec rspec`（364 examples, 0 failures）
- [x] `BUNDLE_GEMFILE=gemfiles/8.0.gemfile bundle exec rspec`
- [x] `BUNDLE_GEMFILE=gemfiles/8.1.gemfile bundle exec rspec`
- [x] `bundle exec rubocop`（no offenses）
- [x] poller スレッドの残存 0 本を確認
- [x] 最小 Rails アプリ + 偽 CopyTuner サーバで上表の 5 構成を実測（puma 8.0.2 / Rails 8.1.3.1 / Ruby 4.0.2）
- [x] `fork_hook_spec.rb` の実 fork テストがフック無しで RED になること（元バグの再現）を確認
- [x] レビューで追加した回帰テスト 9 件がいずれも修正前に RED になることを確認

## 既知の残課題

`register_puma_hook` は依然として Puma の内部実装（`Puma::Runner#start_server` のメソッド名、worker の proctitle 文字列）に依存しており、Puma のバージョンアップで無言で壊れる余地があります。`ForkHook` により一部は安全側に倒れるようになりましたが、根本的な切り離し（`Process.daemon` フック、翻訳 lookup 起点の遅延起動）は別途対応します。上のレビューで見送った 2 件も、どちらもその設計と関係するため同じところで引き取ります。詳細は `docs/poller-startup.md` を参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4czKhcqYizV49oHQA2Erw

